### PR TITLE
Various additions to the wiki

### DIFF
--- a/docs/game-servers.md
+++ b/docs/game-servers.md
@@ -5,6 +5,7 @@ title: Game Servers List
 ---
 
 ## 3DS
+
 | Game                      | Game Server ID | Access Key |
 |---------------------------|----------------|------------|
 | Friends                   | 00003200       | ridfebb9   |
@@ -22,6 +23,7 @@ title: Game Servers List
 See https://kinnay.github.io/view.html?page=nexwiiu
 
 ## Switch
+
 | Game                           | Game Server ID                                           | Access Key                                               | Info                                                |
 |--------------------------------|----------------------------------------------------------|----------------------------------------------------------|-----------------------------------------------------|
 | Luigi's Mansion 3              | 20DE2100                                                 | aab95246                                                 |                                                     |

--- a/docs/nex/protocols/authentication.md
+++ b/docs/nex/protocols/authentication.md
@@ -8,7 +8,7 @@ This is the only protocol that's available on the authentication server. Other p
 
 ## Methods
 
-| Method ID | Name (Wii U)                            | Name (Switch)                                                             |
+| Method ID | Name (3DS / Wii U)                      | Name (Switch)                                                             |
 |-----------|-----------------------------------------|---------------------------------------------------------------------------|
 | 1         | [Login](#1-login)                       | [ValidateAndRequestTicket](#1-login)                                      |
 | 2         | [LoginEx](#2-loginex)                   | [ValidateAndRequestTicketWithCustomData](#2-loginex)                      |

--- a/docs/nex/protocols/datastore/index.md
+++ b/docs/nex/protocols/datastore/index.md
@@ -691,6 +691,11 @@ This method does not return anything.
 | Uint32                       | lockId            |
 | [DataStorePersistenceTarget] | persistenceTarget |
 | Uint64                       | accessPassword    |
+
+In NEX version 3.5, one more field was added:
+
+| Type                         | Name              |
+| ---------------------------- | ----------------- |
 | [List]&lt;[String]&gt;       | extraData         |
 
 ### DataStoreReqGetInfoV1 ([Structure])
@@ -710,6 +715,11 @@ This method does not return anything.
 | [List]&lt;[DataStoreKeyValue]&gt; | requestHeaders |
 | Uint32                            | size           |
 | [Buffer]                          | rootCaCert     |
+
+In NEX version 3.5, one more field was added:
+
+| Type                              | Name           |
+| --------------------------------- | -------------- |
 | Uint64                            | dataId         |
 
 ### DataStoreReqGetAdditionalMeta ([Structure])
@@ -753,6 +763,11 @@ This method does not return anything.
 | [List]&lt;[String]&gt;                           | tags                 |
 | [List]&lt;[DataStoreRatingInitParamWithSlot]&gt; | ratingInitParams     |
 | [DataStorePersistenceInitParam]                  | persistenceInitParam |
+
+In NEX version 3.5, one more field was added:
+
+| Type                                             | Name                 |
+| ------------------------------------------------ | -------------------- |
 | [List]&lt;[String]&gt;                           | extraData            |
 
 ### DataStoreReqPostInfoV1 ([Structure])
@@ -827,6 +842,11 @@ This method does not return anything.
 | Uint16                            | dataType          |
 | Uint8                             | status            |
 | [DataStoreChangeMetaCompareParam] | compareParam      |
+
+Revision 1:
+
+| Type                              | Name              |
+| --------------------------------- | ----------------- |
 | [DataStorePersistenceTarget]      | persistenceTarget |
 
 ### DataStoreGetMetaParam ([Structure])
@@ -890,6 +910,11 @@ Result option flags:
 | Uint64                 | dataId         |
 | Uint32                 | size           |
 | Uint64                 | updatePassword |
+
+In NEX version 3.5, one more field was added:
+
+| Type                   | Name           |
+| ---------------------- | -------------- |
 | [List]&lt;[String]&gt; | extraData      |
 
 ### DataStoreReqUpdateInfo ([Structure])
@@ -930,6 +955,11 @@ Result option flags:
 | [ResultRange]          | resultRange            |
 | Uint8                  | resultOption           |
 | Uint32                 | minimalRatingFrequency |
+
+In NEX version 3.5, one more field was added:
+
+| Type                   | Name                   |
+| ---------------------- | ---------------------- |
 | Bool                   | useCache               |
 
 Only present on Switch:

--- a/docs/nex/protocols/friends-3ds.md
+++ b/docs/nex/protocols/friends-3ds.md
@@ -40,9 +40,9 @@ Official name: `NintendoFriendPresenceProtocol`
 ### (1) UpdateProfile
 #### Request
 
-| Type                    | Description  |
-| ----------------------- | ------------ |
-| [MyProfile](#myprofile) | Profile data |
+| Type                              | Description  |
+| --------------------------------- | ------------ |
+| [MyProfile](#myprofile-structure) | Profile data |
 
 #### Response
 This method does not return anything
@@ -50,9 +50,9 @@ This method does not return anything
 ### (2) UpdateMii
 #### Request
 
-| Type        | Description |
-| ----------- | ----------- |
-| [Mii](#mii) | Mii         |
+| Type                  | Description |
+| --------------------- | ----------- |
+| [Mii](#mii-structure) | Mii         |
 
 #### Response
 This method does not return anything
@@ -60,9 +60,9 @@ This method does not return anything
 ### (3) UpdateMiiList
 #### Request
 
-| Type                | Description |
-| ------------------- | ----------- |
-| [MiiList](#miilist) | Mii list    |
+| Type                          | Description |
+| ----------------------------- | ----------- |
+| [MiiList](#miilist-structure) | Mii list    |
 
 #### Response
 This method does not return anything.
@@ -70,9 +70,9 @@ This method does not return anything.
 ### (4) UpdatePlayedGames
 #### Request
 
-| Type                                    | Description  |
-| --------------------------------------- | ------------ |
-| [List]&lt;[PlayedGame](#playedgame)&gt; | Played games |
+| Type                                              | Description  |
+| ------------------------------------------------- | ------------ |
+| [List]&lt;[PlayedGame](#playedgame-structure)&gt; | Played games |
 
 #### Response
 This method does not return anything.
@@ -80,11 +80,11 @@ This method does not return anything.
 ### (5) UpdatePreference
 #### Request
 
-| Type | Description |
-| ---- | ----------- |
-| Bool | Unknown     |
-| Bool | Unknown     |
-| Bool | Unknown     |
+| Type | Description                  |
+| ---- | ---------------------------- |
+| Bool | Show online presence         |
+| Bool | Show currently playing title |
+| Bool | Show played titles           |
 
 #### Response
 This method does not return anything
@@ -92,97 +92,97 @@ This method does not return anything
 ### (6) GetFriendMii
 #### Request
 
-| Type                                    | Description |
-| --------------------------------------- | ----------- |
-| [List]&lt;[FriendInfo](#friendinfo)&gt; | Friends     |
+| Type                                              | Description |
+| ------------------------------------------------- | ----------- |
+| [List]&lt;[FriendInfo](#friendinfo-structure)&gt; | Friends     |
 
 #### response
 
-| Type                                  | Description |
-| ------------------------------------- | ----------- |
-| [List]&lt;[FriendMii](#friendmii)&gt; | Miis        |
+| Type                                            | Description |
+| ----------------------------------------------- | ----------- |
+| [List]&lt;[FriendMii](#friendmii-structure)&gt; | Miis        |
 
 ### (7) GetFriendMiiList
 #### Request
 
-| Type                                    | Description |
-| --------------------------------------- | ----------- |
-| [List]&lt;[FriendInfo](#friendinfo)&gt; | Friends     |
+| Type                                              | Description |
+| ------------------------------------------------- | ----------- |
+| [List]&lt;[FriendInfo](#friendinfo-structure)&gt; | Friends     |
 
 #### Response
 
-| Type                                          | Description |
-| --------------------------------------------- | ----------- |
-| [List]&lt;[FriendMiiList](#friendmiilist)&gt; | Mii lists   |
+| Type                                                    | Description |
+| ------------------------------------------------------- | ----------- |
+| [List]&lt;[FriendMiiList](#friendmiilist-structure)&gt; | Mii lists   |
 
 ### (8) IsActiveGame
 #### Request
 
-| Type                 | Description |
-| -------------------- | ----------- |
-| [List]&lt;Uint32&gt; | Unknown     |
-| [GameKey](#gamekey)  | Game key    |
+| Type                          | Description   |
+| ----------------------------- | ------------- |
+| [List]&lt;[PID]&gt;           | Principal ids |
+| [GameKey](#gamekey-structure) | Game key      |
 
 #### Response
 
-| Type                 | Description |
-| -------------------- | ----------- |
-| [List]&lt;Uint32&gt; | Unknown     |
+| Type                | Description   |
+| ------------------- | ------------- |
+| [List]&lt;[PID]&gt; | Principal ids |
 
 ### (9) GetPrincipalIDByLocalFriendCode
 #### Request
 
-| Type                 | Description |
-| -------------------- | ----------- |
-| Uint64               | Unknown     |
-| [List]&lt;Uint64&gt; | Unknown     |
+| Type                 | Description        |
+| -------------------- | ------------------ |
+| Uint64               | Local friend code  |
+| [List]&lt;Uint64&gt; | Local friend codes |
 
 #### Response
 
-| Type                                                    | Description          |
-| ------------------------------------------------------- | -------------------- |
-| [List]&lt;[FriendRelationship](#friendrelationship)&gt; | Friend relationships |
+| Type                                                              | Description          |
+| ----------------------------------------------------------------- | -------------------- |
+| [List]&lt;[FriendRelationship](#friendrelationship-structure)&gt; | Friend relationships |
 
 ### (10) GetFriendRelationships
 #### Request
 
-| Type                 | Description |
-| -------------------- | ----------- |
-| [List]&lt;Uint32&gt; | Unknown     |
-
-#### Response
-
-| Type                                                    | Description          |
-| ------------------------------------------------------- | -------------------- |
-| [List]&lt;[FriendRelationship](#friendrelationship)&gt; | Friend relationships |
-
-### (11) AddFriendByPrincipalID
-#### Request
-
-| Type   | Description  |
-| ------ | ------------ |
-| Uint64 | Unknown      |
-| [PID]  | Principal id |
-
-#### Response
-
-| Type                                      | Description         |
-| ----------------------------------------- | ------------------- |
-| [FriendRelationship](#friendrelationship) | Friend relationship |
-
-### (12) AddFriendBylstPrincipalID
-#### Request
-
 | Type                | Description   |
 | ------------------- | ------------- |
-| Uint64              | Unknown       |
 | [List]&lt;[PID]&gt; | Principal ids |
 
 #### Response
 
-| Type                                                    | Description          |
-| ------------------------------------------------------- | -------------------- |
-| [List]&lt;[FriendRelationship](#friendrelationship)&gt; | Friend relationships |
+| Type                                                              | Description          |
+| ----------------------------------------------------------------- | -------------------- |
+| [List]&lt;[FriendRelationship](#friendrelationship-structure)&gt; | Friend relationships |
+
+### (11) AddFriendByPrincipalID
+#### Request
+
+| Type   | Description       |
+| ------ | ----------------- |
+| Uint64 | Local friend code |
+| [PID]  | Principal id      |
+
+#### Response
+
+| Type                                                | Description         |
+| --------------------------------------------------- | ------------------- |
+| [FriendRelationship](#friendrelationship-structure) | Friend relationship |
+
+### (12) AddFriendBylstPrincipalID
+#### Request
+
+| Type                | Description       |
+| ------------------- | ----------------- |
+| Uint64              | Local friend code |
+| [List]&lt;[PID]&gt; | Principal ids     |
+
+#### Response
+
+| Type                                                              | Description          |
+| ----------------------------------------------------------------- | -------------------- |
+| [List]&lt;[FriendRelationship](#friendrelationship-structure)&gt; | Friend relationships |
 
 ### (13) RemoveFriendByLocalFriendCode
 #### Request
@@ -210,9 +210,9 @@ This method does not take any parameters.
 
 #### Response
 
-| Type                                                    | Description          |
-| ------------------------------------------------------- | -------------------- |
-| [List]&lt;[FriendRelationship](#friendrelationship)&gt; | Friend relationships |
+| Type                                                              | Description          |
+| ----------------------------------------------------------------- | -------------------- |
+| [List]&lt;[FriendRelationship](#friendrelationship-structure)&gt; | Friend relationships |
 
 ### (16) UpdateBlackList
 #### Request
@@ -227,25 +227,25 @@ This method does not return anything.
 ### (17) SyncFriend
 #### Request
 
-| Type                 | Description |
-| -------------------- | ----------- |
-| Uint64               | Unknown     |
-| [List]&lt;Uint32&gt; | Unknown     |
-| [List]&lt;Uint64&gt; | Unknown     |
+| Type                 | Description        |
+| -------------------- | ------------------ |
+| Uint64               | Local friend code  |
+| [List]&lt;[PID]&gt;  | Principal ids      |
+| [List]&lt;Uint64&gt; | Local friend codes |
 
 #### Response
 
-| Type                                                    | Description |
-| ------------------------------------------------------- | ----------- |
-| [List]&lt;[FriendRelationship](#friendrelationship)&gt; | Friend list |
+| Type                                                              | Description |
+| ----------------------------------------------------------------- | ----------- |
+| [List]&lt;[FriendRelationship](#friendrelationship-structure)&gt; | Friend list |
 
 ### (18) UpdatePresence
 #### Request
 
-| Type                                  | Description   |
-| ------------------------------------- | ------------- |
-| [NintendoPresence](#nintendopresence) | Presence info |
-| Bool                                  | Unknown       |
+| Type                                            | Description                  |
+| ----------------------------------------------- | ---------------------------- |
+| [NintendoPresence](#nintendopresence-structure) | Presence info                |
+| Bool                                            | Show currently playing title |
 
 #### Response
 This method does not return anything
@@ -253,9 +253,9 @@ This method does not return anything
 ### (19) UpdateFavoriteGameKey
 #### Request
 
-| Type                | Description |
-| ------------------- | ----------- |
-| [GameKey](#gamekey) | Game key    |
+| Type                          | Description |
+| ----------------------------- | ----------- |
+| [GameKey](#gamekey-structure) | Game key    |
 
 #### Response
 This method does not return anything.
@@ -284,28 +284,28 @@ This method does not return anything
 ### (22) GetFriendPresence
 #### Request
 
-| Type                 | Description |
-| -------------------- | ----------- |
-| [List]&lt;Uint32&gt; | Unknown     |
+| Type                | Description   |
+| ------------------- | ------------- |
+| [List]&lt;[PID]&gt; | Principal ids |
 
 #### Response
 
-| Type                                            | Description          |
-| ----------------------------------------------- | -------------------- |
-| [List]&lt;[FriendPresence](#friendpresence)&gt; | Friend presence list |
+| Type                                                      | Description          |
+| --------------------------------------------------------- | -------------------- |
+| [List]&lt;[FriendPresence](#friendpresence-structure)&gt; | Friend presence list |
 
 ### (23) GetFriendComment
 #### Request
 
-| Type                                    | Description |
-| --------------------------------------- | ----------- |
-| [List]&lt;[FriendInfo](#friendinfo)&gt; | Friend info |
+| Type                                              | Description |
+| ------------------------------------------------- | ----------- |
+| [List]&lt;[FriendInfo](#friendinfo-structure)&gt; | Friend info |
 
 #### Response
 
-| Type                                          | Description |
-| --------------------------------------------- | ----------- |
-| [List]&lt;[FriendComment](#friendcomment)&gt; | Comments    |
+| Type                                                    | Description |
+| ------------------------------------------------------- | ----------- |
+| [List]&lt;[FriendComment](#friendcomment-structure)&gt; | Comments    |
 
 ### (24) GetFriendPicture
 #### Request
@@ -316,29 +316,29 @@ This method does not return anything
 
 #### Response
 
-| Type                                          | Description     |
-| --------------------------------------------- | --------------- |
-| [List]&lt;[FriendPicture](#friendpicture)&gt; | Friend pictures |
+| Type                                                    | Description     |
+| ------------------------------------------------------- | --------------- |
+| [List]&lt;[FriendPicture](#friendpicture-structure)&gt; | Friend pictures |
 
 ### (25) GetFriendPersistentInfo
 #### Request
 
-| Type                 | Description |
-| -------------------- | ----------- |
-| [List]&lt;Uint32&gt; | Unknown     |
+| Type                | Description   |
+| ------------------- | ------------- |
+| [List]&lt;[PID]&gt; | Principal ids |
 
 #### Response
 
-| Type                                                        | Description     |
-| ----------------------------------------------------------- | --------------- |
-| [List]&lt;[FriendPersistentInfo](#friendpersistentinfo)&gt; | Persistent info |
+| Type                                                                  | Description     |
+| --------------------------------------------------------------------- | --------------- |
+| [List]&lt;[FriendPersistentInfo](#friendpersistentinfo-structure)&gt; | Persistent info |
 
 ### (26) SendInvitation
 #### Request
 
-| Type                 | Description |
-| -------------------- | ----------- |
-| [List]&lt;Uint32&gt; | Unknown     |
+| Type                | Description   |
+| ------------------- | ------------- |
+| [List]&lt;[PID]&gt; | Principal ids |
 
 #### Response
 This method does not return anything
@@ -348,56 +348,56 @@ This method does not return anything
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type       | Description |
-| ---------- | ----------- |
-| Uint32     | Unknown     |
-| [String]   | Comment     |
-| [DateTime] | Unknown     |
+| Type       | Description  |
+| ---------- | ------------ |
+| [PID]      | Principal id |
+| [String]   | Comment      |
+| [DateTime] | Modified at  |
 
 ### FriendInfo ([Structure])
 
-| Type       | Description |
-| ---------- | ----------- |
-| Uint32     | Unknown     |
-| [DateTime] | Unknown     |
+| Type       | Description  |
+| ---------- | ------------ |
+| [PID]      | Principal id |
+| [DateTime] | Unknown      |
 
 ### FriendMii ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type        | Description |
-| ----------- | ----------- |
-| Uint32      | Unknown     |
-| [Mii](#mii) | Mii         |
-| [DateTime]  | Unknown     |
+| Type                  | Description  |
+| --------------------- | ------------ |
+| [PID]                 | Principal id |
+| [Mii](#mii-structure) | Mii          |
+| [DateTime]            | Modified at  |
 
 ### FriendMiiList ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type                | Description |
-| ------------------- | ----------- |
-| Uint32              | Unknown     |
-| [MiiList](#miilist) | Mii list    |
-| [DateTime]          | Unknown     |
+| Type                          | Description |
+| ----------------------------- | ----------- |
+| Uint32                        | Unknown     |
+| [MiiList](#miilist-structure) | Mii list    |
+| [DateTime]                    | Unknown     |
 
 ### FriendPersistentInfo ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type                | Description        |
-| ------------------- | ------------------ |
-| [PID]               | User id            |
-| Uint8               | Region             |
-| Uint8               | Country            |
-| Uint8               | Area               |
-| Uint8               | Language           |
-| Uint8               | Platform           |
-| [GameKey](#gamekey) | Game key           |
-| [String]            | Message            |
-| [DateTime]          | Message updated at |
-| [DateTime]          | Friended at        |
-| [DateTime]          | Unknown            |
+| Type                          | Description        |
+| ----------------------------- | ------------------ |
+| [PID]                         | User id            |
+| Uint8                         | Region             |
+| Uint8                         | Country            |
+| Uint8                         | Area               |
+| Uint8                         | Language           |
+| Uint8                         | Platform           |
+| [GameKey](#gamekey-structure) | Game key           |
+| [String]                      | Message            |
+| [DateTime]                    | Message updated at |
+| [DateTime]                    | Friended at        |
+| [DateTime]                    | Last online at     |
 
 ### FriendPicture ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
@@ -413,29 +413,37 @@ This method does not return anything
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type                                  | Description       |
-| ------------------------------------- | ----------------- |
-| Uint32                                | Unknown           |
-| [NintendoPresence](#nintendopresence) | Nintendo presence |
+| Type                                            | Description       |
+| ----------------------------------------------- | ----------------- |
+| [PID]                                           | Principal id      |
+| [NintendoPresence](#nintendopresence-structure) | Nintendo presence |
 
 ### FriendRelationship ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type   | Description |
-| ------ | ----------- |
-| Uint32 | Unknown     |
-| Uint64 | Unknown     |
-| Uint8  | Unknown     |
+| Type   | Description       |
+| ------ | ----------------- |
+| [PID]  | Principal id      |
+| Uint64 | Local friend code |
+| Uint8  | Relationship type |
+
+Relationship types:
+
+| Type   | Description           |
+| ------ | --------------------- |
+| 0      | Friendship incomplete |
+| 1      | Friendship complete   |
+| 2      | Friend does not exist |
 
 ### GameKey ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type   | Description   |
-| ------ | ------------- |
-| Uint64 | Title id      |
-| Uint16 | Title version |
+| Type   | Name          | Description   |
+| ------ | ------------- | ------------- |
+| Uint64 | m_gameCode    | Title id      |
+| Uint16 | m_gameVersion | Title version |
 
 ### Mii ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
@@ -443,7 +451,7 @@ This method does not return anything
 
 | Type     | Description |
 | -------- | ----------- |
-| [String] | Unknown     |
+| [String] | Name        |
 | Bool     | Unknown     |
 | Uint8    | Unknown     |
 | [Buffer] | Mii data    |
@@ -478,27 +486,27 @@ This method does not return anything
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type                | Name                   |
-| ------------------- | ---------------------- |
-| Uint32              | m_changedBitFlag       |
-| [GameKey](#gamekey) | m_gameKey              |
-| [String]            | m_gameModeDescription  |
-| Uint32              | m_joinAvailabilityFlag |
-| Uint8               | m_matchmakeSystemType  |
-| Uint32              | m_joinGameID           |
-| Uint32              | m_joinGameMode         |
-| [PID]               | m_ownerPrincipalID     |
-| Uint32              | m_joinGroupID          |
-| [Buffer]            | m_applicationArg       |
+| Type                          | Name                   |
+| ----------------------------- | ---------------------- |
+| Uint32                        | m_changedBitFlag       |
+| [GameKey](#gamekey-structure) | m_gameKey              |
+| [String]                      | m_gameModeDescription  |
+| Uint32                        | m_joinAvailabilityFlag |
+| Uint8                         | m_matchmakeSystemType  |
+| Uint32                        | m_joinGameID           |
+| Uint32                        | m_joinGameMode         |
+| [PID]                         | m_ownerPrincipalID     |
+| Uint32                        | m_joinGroupID          |
+| [Buffer]                      | m_applicationArg       |
 
 ### PlayedGame ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type                | Description |
-| ------------------- | ----------- |
-| [GameKey](#gamekey) | Game key    |
-| [DateTime]          | Date time   |
+| Type                          | Description |
+| ----------------------------- | ----------- |
+| [GameKey](#gamekey-structure) | Game key    |
+| [DateTime]                    | Date time   |
 
 [Structure]: NEX-Common-Types#structure
 [Data]: NEX-Common-Types#data-structure

--- a/docs/nex/protocols/index.md
+++ b/docs/nex/protocols/index.md
@@ -78,7 +78,7 @@ Ubisoft games always use the original Quazal Rendez-Vous library instead of NEX.
 | 47  | Ubi friends                                                                  |
 | 48  | Skill rating                                                                 |
 | 49  | [Uplay win](/docs/nex/protocols/uplay-win)                                   |
-| 51  | Title storage                                                                |
+| 51  | [Title storage](/docs/nex/protocols/title-storage)                           |
 | 53  | [User storage](/docs/nex/protocols/user-storage)                             |
 | 55  | [Player stats](/docs/nex/protocols/player-stats)                             |
 | 60  | Spark                                                                        |
@@ -86,4 +86,6 @@ Ubisoft games always use the original Quazal Rendez-Vous library instead of NEX.
 | 72  | [User account management](/docs/nex/protocols/user-account-management)       |
 | 84  | Siege admin                                                                  |
 | ?   | [Web notifications storage](/docs/nex/protocols/web-notifications-storage)   |
+| ?   | [Title storage admin](/docs/nex/protocols/title-storage-admin)               |
 | ?   | [User storage admin](/docs/nex/protocols/user-storage-admin)                 |
+| ?   | [OLS storage](/docs/nex/protocols/ols-storage)                               |

--- a/docs/nex/protocols/match-making/types.md
+++ b/docs/nex/protocols/match-making/types.md
@@ -65,7 +65,7 @@ In NEX version 3.0, the session key was added:
 | -------- | ------------ |
 | [Buffer] | m_SessionKey |
 
-In NEX version 3.5, two more fields were added. Note that the progress score field was inserted before the session key field:
+In NEX version 3.4, a progress score field was added. Note that this field was inserted before the session key field:
 
 | Type                 | Name                  |
 | -------------------- | --------------------- |
@@ -77,6 +77,11 @@ In NEX version 3.5, two more fields were added. Note that the progress score fie
 | Uint32               | m_ParticipationCount  |
 | Uint8                | m_ProgressScore       |
 | [Buffer]             | m_SessionKey          |
+
+In NEX version 3.5, one more field was added:
+
+| Type                 | Name                  |
+| -------------------- | --------------------- |
 | Uint32               | m_Option0             |
 
 In NEX version 3.6, the revision number was increased to 1 and two more fields were added:
@@ -107,7 +112,7 @@ In NEX version 4.0, the revision number was set back to 0 and one more field was
 | [String] | m_Codeword | NEX v4.0.0 and later |
 
 ## MatchmakeSessionSearchCriteria ([Structure])
-Up to NEX version 3.4, this structure looks as follows:
+Up to NEX version 3.3, this structure looks as follows:
 
 | Type                   | Name                  |
 | ---------------------- | --------------------- |
@@ -121,7 +126,7 @@ Up to NEX version 3.4, this structure looks as follows:
 | Bool                   | m_ExcludeNonHostPid   |
 | Uint32                 | m_SelectionMethod     |
 
-In NEX version 3.5, one more field was added:
+In NEX version 3.4, one more field was added:
 
 | Type   | Name                 |
 | ------ | -------------------- |

--- a/docs/nex/protocols/nintendo-notifications.md
+++ b/docs/nex/protocols/nintendo-notifications.md
@@ -59,35 +59,42 @@ No RMC response is sent.
 
 ## Friend Events
 
-| Type | Method | Data Type                          | Description                                                                       |
-| ---- | ------ | ---------------------------------- | --------------------------------------------------------------------------------- |
-| 10   | 1      | [NintendoNotificationEventGeneral] | A friend went offline                                                             |
-| 21   | 2      | [NNAInfo]                          | A friend changed or edited their mii                                              |
-| 22   |        |                                    | Mii related                                                                       |
-| 23   |        | [PrincipalPreference]              | A friend updated their preferences                                                |
-| 24   | 2      | [NintendoPresenceV2]               | A friend started a game/app                                                       |
-| 25   |        |                                    | Friend request related                                                            |
-| 26   | 1      | [NintendoNotificationEventGeneral] | A friend removed you from their from friend list or canceled their friend request |
-| 27   | 2      | [FriendRequest]                    | You received a friend request                                                     |
-| 28   |        |                                    | Friend request related                                                            |
-| 29   |        |                                    | Blacklist related                                                                 |
-| 30   | 1      | [FriendInfo]                       | You became friends                                                                |
-| 31   |        |                                    | Blacklist related                                                                 |
-| 32   |        |                                    | Blacklist related                                                                 |
-| 33   | 1      | [NintendoNotificationEventGeneral] | A friend changed their status message                                             |
-| 34   |        |                                    |                                                                                   |
-| 35   |        |                                    | Related to friend relationships                                                   |
-| 36   |        | [PersistentNotificationList]       | This seems to delete persistent notifications                                     |
+| Type | Method | Data Type                          | Description                                                                               |
+| ---- | ------ | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| 1    | 1      | [NintendoPresence]                 | (3DS) A friend updated their presence                                                     |
+| 2    | 1      | [GameKey]                          | (3DS) A friend changed their favorite game                                                |
+| 3    | 1      | [NintendoNotificationEventGeneral] | (3DS) A friend changed their comment                                                      |
+| 5    | 1      | [NintendoNotificationEventGeneral] | (3DS) A friend changed or edited their mii                                                |
+| 7    | 1      | [NintendoNotificationEventGeneral] | (3DS) You became friends                                                                  |
+| 10   | 1      | [NintendoNotificationEventGeneral] | (3DS & Wii U) A friend went offline                                                       |
+| 21   | 2      | [NNAInfo]                          | (Wii U) A friend changed or edited their mii                                              |
+| 22   |        |                                    | (Wii U) Mii related                                                                       |
+| 23   |        | [PrincipalPreference]              | (Wii U) A friend updated their preferences                                                |
+| 24   | 2      | [NintendoPresenceV2]               | (Wii U) A friend started a game/app                                                       |
+| 25   |        |                                    | (Wii U) Friend request related                                                            |
+| 26   | 1      | [NintendoNotificationEventGeneral] | (Wii U) A friend removed you from their from friend list or canceled their friend request |
+| 27   | 2      | [FriendRequest]                    | (Wii U) You received a friend request                                                     |
+| 28   |        |                                    | (Wii U) Friend request related                                                            |
+| 29   |        |                                    | (Wii U) Blacklist related                                                                 |
+| 30   | 1      | [FriendInfo]                       | (Wii U) You became friends                                                                |
+| 31   |        |                                    | (Wii U) Blacklist related                                                                 |
+| 32   |        |                                    | (Wii U) Blacklist related                                                                 |
+| 33   | 1      | [NintendoNotificationEventGeneral] | (Wii U) A friend changed their status message                                             |
+| 34   |        |                                    |                                                                                           |
+| 35   |        |                                    | (Wii U) Related to friend relationships                                                   |
+| 36   |        | [PersistentNotificationList]       | (Wii U) This seems to delete persistent notifications                                     |
 
 [Data]: /docs/nex/types#anydataholder
 [PID]: /docs/nex/types#pid
 [Structure]: /docs/nex/types#structure
 [String]: /docs/nex/types#string
-[FriendRequest]: /docs/nex/protocols/friends-wiiu#friendrequest
-[NintendoPresenceV2]: /docs/nex/protocols/friends-wiiu#nintendopresencev2
-[FriendInfo]: /docs/nex/protocols/friends-wiiu#friendinfo
-[NNAInfo]: /docs/nex/protocols/friends-wiiu#nnainfo
-[MiiV2]: /docs/nex/protocols/friends-wiiu#miiv2
-[PrincipalPreference]: /docs/nex/protocols/friends-wiiu#principalpreference
-[PersistentNotificationList]: /docs/nex/protocols/friends-wiiu#persistentnotificationlist
+[NintendoPresence]: /docs/nex/protocols/friends-3ds#nintendopresence-structure
+[GameKey]: /docs/nex/protocols/friends-3ds#gamekey-structure
+[FriendRequest]: /docs/nex/protocols/friends-wiiu#friendrequest-structure
+[NintendoPresenceV2]: /docs/nex/protocols/friends-wiiu#nintendopresencev2-structure
+[FriendInfo]: /docs/nex/protocols/friends-wiiu#friendinfo-structure
+[NNAInfo]: /docs/nex/protocols/friends-wiiu#nnainfo-structure
+[MiiV2]: /docs/nex/protocols/friends-wiiu#miiv2-structure
+[PrincipalPreference]: /docs/nex/protocols/friends-wiiu#principalpreference-structure
+[PersistentNotificationList]: /docs/nex/protocols/friends-wiiu#persistentnotificationlist-structure
 [NintendoNotificationEventGeneral]: #nintendonotificationeventgeneral-structure

--- a/docs/nex/protocols/nintendo-notifications.md
+++ b/docs/nex/protocols/nintendo-notifications.md
@@ -66,7 +66,7 @@ No RMC response is sent.
 | 3    | 1      | [NintendoNotificationEventGeneral] | (3DS) A friend changed their comment                                                      |
 | 5    | 1      | [NintendoNotificationEventGeneral] | (3DS) A friend changed or edited their mii                                                |
 | 7    | 1      | [NintendoNotificationEventGeneral] | (3DS) You became friends                                                                  |
-| 10   | 1      | [NintendoNotificationEventGeneral] | (3DS & Wii U) A friend went offline                                                       |
+| 10   | 1      | [NintendoNotificationEventGeneral] | (3DS / Wii U) A friend went offline                                                       |
 | 21   | 2      | [NNAInfo]                          | (Wii U) A friend changed or edited their mii                                              |
 | 22   |        |                                    | (Wii U) Mii related                                                                       |
 | 23   |        | [PrincipalPreference]              | (Wii U) A friend updated their preferences                                                |

--- a/docs/nex/protocols/notifications.md
+++ b/docs/nex/protocols/notifications.md
@@ -24,7 +24,7 @@ No RMC response is sent.
 ### NotificationEvent ([Structure])
 Most notification types are predefined. However, some games also implement their own notification types (see [libeagle](/docs/switch/eagle) for example).
 
-**Wii U:**
+**Wii U and 3DS:**
 
 | Type     | Name        |
 | -------- | ----------- |
@@ -33,6 +33,12 @@ Most notification types are predefined. However, some games also implement their
 | Uint32   | m_uiParam1  |
 | Uint32   | m_uiParam2  |
 | [String] | m_strParam  |
+
+In NEX version 3.5, a new field was added:
+
+| Type     | Name       |
+| -------- | ---------- |
+| Uint32   | m_uiParam3 |
 
 **Switch:**
 
@@ -67,6 +73,7 @@ The following field is only present in revision 1:
 | 4000   | Ownership changed               |
 | 109000 | Gathering unregistered          |
 | 110000 | Host changed                    |
+| 115000 | Service item request completed  |
 | 116000 | Matchmake referee round started |
 | 120000 | System password changed         |
 | 121000 | System password cleared         |
@@ -106,6 +113,14 @@ The following field is only present in revision 1:
 | ----------- | ------------ |
 | m_pidSource | Principal id |
 | m_uiParam1  | Gathering id |
+
+### Notification type 115000:
+
+| Field       | Description                     |
+| ----------- | ------------------------------- |
+| m_pidSource | Principal that made the request |
+| m_uiParam1  | Request id                      |
+| m_uiParam2  | Unknown                         |
 
 ### Notification type 116000:
 

--- a/docs/nex/protocols/ols-storage.md
+++ b/docs/nex/protocols/ols-storage.md
@@ -1,0 +1,447 @@
+---
+layout: post
+toc: true
+title: OLS Storage
+---
+
+## Methods
+
+| Method ID | Method Name                                              |
+| --------- | -------------------------------------------------------- |
+| 1         | [LoadVersion](#1-loadversion)                            |
+| 2         | [SaveLocale](#2-savelocale)                              |
+| 3         | [SaveProfile](#3-saveprofile)                            |
+| 4         | [LoadIDCard](#4-loadidcard)                              |
+| 5         | [QueryFriendProfiles](#5-queryfriendprofiles)            |
+| 6         | [QueryUbisoftProfiles](#6-queryubisoftprofiles)          |
+| 7         | [CreateMessage](#7-createmessage)                        |
+| 8         | [QueryMessage](#8-querymessage)                          |
+| 9         | [QueryLeaderboard](#9-queryleaderboard)                  |
+| 10        | [QuerySmartSelection](#10-querysmartselection)           |
+| 11        | [SaveScore](#11-savescore)                               |
+| 12        | [SaveGhost](#12-saveghost)                               |
+| 13        | [QueryCompetitionsInfos](#13-querycompetitionsinfos)     |
+| 14        | [QueryCompetitionsHistory](#14-querycompetitionshistory) |
+| 15        | [QueryCompetitionOfTheDay](#15-querycompetitionoftheday) |
+| 16        | [QueryCompetition](#16-querycompetition)                 |
+
+### (1) LoadVersion
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type     | Name        |
+| -------- | ----------- |
+| Sint32   | version     |
+| [String] | sandboxName |
+
+### (2) SaveLocale
+
+#### Request
+
+| Type     | Name       |
+| -------- | ---------- |
+| [String] | localeCode |
+
+#### Response
+This method does not return anything
+
+### (3) SaveProfile
+
+#### Request
+
+| Type   | Name              |
+| ------ | ----------------- |
+| Uint32 | update_bitfield   |
+| Sint8  | level             |
+| Sint32 | currency          |
+| Uint32 | costume           |
+| Uint16 | bronze_medals     |
+| Uint16 | silver_medals     |
+| Uint16 | gold_medals       |
+| Uint16 | diamond_medals    |
+| Uint32 | run_distance      |
+| Uint16 | teensies_freed    |
+| Uint32 | jumps             |
+| Uint16 | unlocked_pets     |
+| Uint64 | pets              |
+| Uint16 | unlocked_costumes |
+
+#### Response
+
+| Type   | Name                 |
+| ------ | -------------------- |
+| Uint16 | competition_medals_0 |
+| Uint16 | competition_medals_1 |
+| Uint16 | competition_medals_2 |
+| Uint16 | competition_medals_3 |
+
+### (4) LoadIDCard
+
+#### Request
+
+| Type  | Name |
+| ----- | ---- |
+| [PID] | pid  |
+
+#### Response
+
+| Type                                        | Name    |
+| ------------------------------------------- | ------- |
+| [OLSRichProfile](#olsrichprofile-structure) | profile |
+
+### (5) QueryFriendProfiles
+
+#### Request
+
+| Type                                                | Name    |
+| --------------------------------------------------- | ------- |
+| [List]&#x3C;[OLSFriend](#olsfriend-structure)&#x3E; | friends |
+
+#### Response
+
+| Type                                                  | Name     |
+| ----------------------------------------------------- | -------- |
+| [List]&#x3C;[OLSProfile](#olsprofile-structure)&#x3E; | profiles |
+
+### (6) QueryUbisoftProfiles
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type                                                  | Name     |
+| ----------------------------------------------------- | -------- |
+| [List]&#x3C;[OLSProfile](#olsprofile-structure)&#x3E; | profiles |
+
+### (7) CreateMessage
+
+#### Request
+
+| Type                                                      | Name         |
+| --------------------------------------------------------- | ------------ |
+| Uint32                                                    | message_type |
+| [List]&#x3C;Sint32&#x3E;                                  | receivers    |
+| [List]&#x3C;[OLSAttribute](#olsattribute-structure)&#x3E; | attributes   |
+
+#### Response
+This method does not return anything
+
+### (8) QueryMessage
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type                                                  | Name     |
+| ----------------------------------------------------- | -------- |
+| [List]&#x3C;[OLSMessage](#olsmessage-structure)&#x3E; | messages |
+
+### (9) QueryLeaderboard
+
+#### Request
+
+| Type   | Name           |
+| ------ | -------------- |
+| Uint32 | id_leaderboard |
+
+#### Response
+
+| Type                                                | Name         |
+| --------------------------------------------------- | ------------ |
+| [List]&#x3C;[OLSLdbRow](#olsldbrow-structure)&#x3E; | result       |
+| [List]&#x3C;Float&#x3E;                             | graduations  |
+| [List]&#x3C;Uint32&#x3E;                            | envelope     |
+| Uint32                                              | unit         |
+| Uint32                                              | my_country   |
+| Uint32                                              | participants |
+| Bool                                                | cacheable    |
+
+### (10) QuerySmartSelection
+
+#### Request
+
+| Type   | Name           |
+| ------ | -------------- |
+| Uint32 | id_leaderboard |
+
+#### Response
+
+| Type                                                            | Name   |
+| --------------------------------------------------------------- | ------ |
+| [List]&#x3C;[OLSSelectionRow](#olsselectionrow-structure)&#x3E; | ghosts |
+| [List]&#x3C;[OLSTomb](#olstomb-structure)&#x3E;                 | tombs  |
+
+### (11) SaveScore
+
+#### Request
+
+| Type   | Name                 |
+| ------ | -------------------- |
+| Uint32 | id_leaderboard       |
+| Bool   | is_objective_reached |
+| Float  | score                |
+| Float  | tomb_x               |
+| Float  | tomb_y               |
+| Float  | tomb_z               |
+| Uint32 | id_costume           |
+
+#### Response
+
+| Type     | Name            |
+| -------- | --------------- |
+| Bool     | save_score      |
+| Bool     | retry           |
+| Uint32   | medal           |
+| [String] | message_medal   |
+| [String] | message_friends |
+
+### (12) SaveGhost
+
+#### Request
+
+| Type   | Name           |
+| ------ | -------------- |
+| Uint64 | id_ghost       |
+| Uint32 | id_competition |
+| Uint32 | id_costume     |
+| Float  | score          |
+
+#### Response
+This method does not return anything
+
+### (13) QueryCompetitionsInfos
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type                                                                    | Name  |
+| ----------------------------------------------------------------------- | ----- |
+| [List]&#x3C;[OLSCompetitionInfos](#olscompetitioninfos-structure)&#x3E; | infos |
+
+### (14) QueryCompetitionsHistory
+
+#### Request
+
+| Type   | Name                |
+| ------ | ------------------- |
+| Uint32 | begin               |
+| Uint32 | amount              |
+| Uint32 | id_competition_meta |
+
+#### Response
+
+| Type                                                                      | Name    |
+| ------------------------------------------------------------------------- | ------- |
+| [List]&#x3C;[OLSCompetitionResult](#olscompetitionresult-structure)&#x3E; | history |
+| Uint32                                                                    | total   |
+
+### (15) QueryCompetitionOfTheDay
+
+#### Request
+
+| Type   | Name                |
+| ------ | ------------------- |
+| Uint32 | id_competition_meta |
+
+#### Response
+
+| Type                                        | Name            |
+| ------------------------------------------- | --------------- |
+| [OLSCompetition](#olscompetition-structure) | competition     |
+| Uint32                                      | remaningSeconds |
+| [OLSCompetition](#olscompetition-structure) | tomorrow        |
+
+### (16) QueryCompetition
+
+#### Request
+
+| Type   | Name           |
+| ------ | -------------- |
+| Uint32 | id_competition |
+
+#### Response
+
+| Type                                        | Name        |
+| ------------------------------------------- | ----------- |
+| [OLSCompetition](#olscompetition-structure) | competition |
+
+## Types
+
+### OLSProfile ([Structure])
+
+| Type     | Name       |
+| -------- | ---------- |
+| Sint32   | PID        |
+| [String] | PlatformID |
+| [String] | Name       |
+| Uint32   | costume    |
+| Uint32   | country    |
+| Sint8    | level      |
+
+### OLSRichProfile ([Structure])
+
+| Type | Name |
+| --- | --- |
+| Sint32   | PID                  |
+| [String] | Name                 |
+| [String] | PlatformID           |
+| Sint16   | Country              |
+| Uint32   | StatusIcon           |
+| Uint32   | lastCostume          |
+| Uint16   | totalChallengePlayed |
+| Bool     | dailyPlayed          |
+| Bool     | weeklyPlayed         |
+| Bool     | dailyExpertPlayed    |
+| Bool     | weeklyExpertPlayed   |
+| Uint16   | DiamondMedals        |
+| Uint16   | GoldMedals           |
+| Uint16   | SilverMedals         |
+| Uint16   | BronzeMedals         |
+| Uint32   | GlobalMedalsRank     |
+| Uint32   | GlobalMedalsMaxRank  |
+| Float    | distanceRun          |
+| Uint32   | rank_distanceRun     |
+| Float    | lums                 |
+| Uint32   | rank_lums            |
+| Float    | pets                 |
+| Uint32   | rank_pets            |
+| Float    | teensies             |
+| Uint32   | rank_teensies        |
+| Float    | jumps                |
+| Uint32   | rank_jumps           |
+| Float    | costumes             |
+| Uint32   | rank_costumes        |
+| Float    | stat_daily           |
+| Uint32   | rank_daily           |
+| Sint8    | unit_daily           |
+| Float    | stat_weekly          |
+| Uint32   | rank_weekly          |
+| Sint8    | unit_weekly          |
+| Float    | stat_daily_expert    |
+| Uint32   | rank_daily_expert    |
+| Sint8    | unit_daily_expert    |
+| Float    | stat_weekly_expert   |
+| Uint32   | rank_weekly_expert   |
+| Sint8    | unit_weekly_expert   |
+
+### OLSAttribute ([Structure])
+
+| Type   | Name            |
+| ------ | --------------- |
+| Sint8  | attribute_type  |
+| Uint32 | attribute_value |
+
+### OLSMessage ([Structure])
+
+| Type                                                      | Name               |
+| --------------------------------------------------------- | ------------------ |
+| Sint8                                                     | message_type       |
+| Bool                                                      | message_prompt     |
+| Bool                                                      | message_drc        |
+| Bool                                                      | message_bloomberg  |
+| [DateTime]                                                | message_date       |
+| Uint32                                                    | message_duration   |
+| [String]                                                  | message_title      |
+| [String]                                                  | message_body       |
+| [List]&#x3C;[String]&#x3E;                                | message_buttons    |
+| [List]&#x3C;[OLSAttribute](#olsattribute-structure)&#x3E; | message_attributes |
+
+### OLSCompetitionResult ([Structure])
+
+| Type       | Name           |
+| ---------- | -------------- |
+| Uint32     | id_leaderboard |
+| [String]   | name           |
+| [DateTime] | begin          |
+| [DateTime] | end            |
+| Uint32     | level          |
+| Uint32     | mode           |
+| Uint32     | rank           |
+| Uint32     | max_rank       |
+
+### OLSCompetition ([Structure])
+
+| Type                                                    | Name             |
+| ------------------------------------------------------- | ---------------- |
+| [OLSCompetitionResult](#olscompetitionresult-structure) | result           |
+| [String]                                                | message          |
+| Uint32                                                  | seed             |
+| Float                                                   | objective        |
+| Float                                                   | score_validation |
+| Uint32                                                  | id_bricks        |
+| Float                                                   | score            |
+
+### OLSSelectionRow ([Structure])
+
+| Type     | Name       |
+| -------- | ---------- |
+| Uint32   | ID         |
+| [String] | name       |
+| Uint64   | id_ghost   |
+| Uint32   | id_costume |
+| Uint32   | country    |
+| Uint32   | level      |
+| Float    | score      |
+
+### OLSCompetitionInfos ([Structure])
+
+| Type                                                            | Name              |
+| --------------------------------------------------------------- | ----------------- |
+| Uint32                                                          | id_competition    |
+| Uint32                                                          | participants      |
+| [List]&#x3C;Uint32&#x3E;                                        | friends           |
+| Uint32                                                          | level_id          |
+| Uint32                                                          | mode              |
+| Uint32                                                          | my_rank           |
+| Uint32                                                          | remaining_seconds |
+| [List]&#x3C;[OLSSelectionRow](#olsselectionrow-structure)&#x3E; | competitors       |
+| Uint32                                                          | unit              |
+
+### OLSLdbRow ([Structure])
+
+| Type     | Name       |
+| -------- | ---------- |
+| Uint32   | ID         |
+| [String] | name       |
+| Float    | value      |
+| Uint32   | costume    |
+| Uint32   | statusIcon |
+| Uint32   | country    |
+
+### OLSTomb ([Structure])
+
+| Type     | Name       |
+| -------- | ---------- |
+| Sint32   | pid        |
+| [String] | name       |
+| Uint32   | id_costume |
+| Float    | x          |
+| Float    | y          |
+| Float    | z          |
+
+### OLSFriend ([Structure])
+
+| Type   | Name         |
+| ------ | ------------ |
+| Sint32 | pid          |
+| Uint32 | relationship |
+
+[Result]: /docs/nex/types#result
+[String]: /docs/nex/types#string
+[Buffer]: /docs/nex/types#buffer
+[qBuffer]: /docs/nex/types#qbuffer
+[List]: /docs/nex/types#list
+[Map]: /docs/nex/types#map
+[DateTime]: /docs/nex/types#datetime
+[Structure]: /docs/nex/types#structure
+[Data]: /docs/nex/types#anydataholder
+[StationURL]: /docs/nex/types#stationurl
+[Variant]: /docs/nex/types#variant
+[PID]: /docs/nex/types#pid

--- a/docs/nex/protocols/service-item.md
+++ b/docs/nex/protocols/service-item.md
@@ -343,19 +343,19 @@ title: Service Item (119)
 
 ## Types
 
-## ServiceItemHttpGetParam ([Structure])
+### ServiceItemHttpGetParam ([Structure])
 
 | Type     | Name |
 | -------- | ---- |
 | [String] | url  |
 
-## ServiceItemHttpGetResponse ([Structure])
+### ServiceItemHttpGetResponse ([Structure])
 
 | Type      | Name     |
 | --------- | -------- |
 | [qBuffer] | response |
 
-## ServiceItemEShopResponse ([Structure])
+### ServiceItemEShopResponse ([Structure])
 
 | Type     | Name          |
 | -------- | ------------- |
@@ -363,7 +363,7 @@ title: Service Item (119)
 | Uint32   | errorCode     |
 | [String] | correlationId |
 
-## ServiceItemAmount ([Structure])
+### ServiceItemAmount ([Structure])
 
 | Type     | Name            |
 | -------- | --------------- |
@@ -371,7 +371,7 @@ title: Service Item (119)
 | [String] | currency        |
 | [String] | rawValue        |
 
-## ServiceItemPurchaseServiceItemParam ([Structure])
+### ServiceItemPurchaseServiceItemParam ([Structure])
 
 | Type     | Name           |
 | -------- | -------------- |
@@ -390,7 +390,7 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemPurchaseInfo ([Structure])
+### ServiceItemPurchaseInfo ([Structure])
 
 | Type                                    | Name             |
 | --------------------------------------- | ---------------- |
@@ -399,7 +399,7 @@ Revision 1:
 | [String]                                | itemCode         |
 | [ServiceItemAmount](#serviceitemamount) | postBalance      |
 
-## ServiceItemPurchaseServiceItemResponse ([Structure])
+### ServiceItemPurchaseServiceItemResponse ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemEShopResponse](#serviceitemeshopresponse-structure)
 {: .prompt-info }
 
@@ -407,7 +407,7 @@ Revision 1:
 | --------------------------------------------------------------------------- | -------------------- |
 | [List]&lt;[ServiceItemPurchaseInfo](#serviceitempurchaseinfo-structure)&gt; | nullablePurchaseInfo |
 
-## ServiceItemListServiceItemParam ([Structure])
+### ServiceItemListServiceItemParam ([Structure])
 
 | Type     | Name               |
 | -------- | ------------------ |
@@ -423,21 +423,21 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemLimitation ([Structure])
+### ServiceItemLimitation ([Structure])
 
 | Type   | Name            |
 | ------ | --------------- |
 | Uint32 | limitationType  |
 | Uint32 | limitationValue |
 
-## ServiceItemAttribute ([Structure])
+### ServiceItemAttribute ([Structure])
 
 | Type     | Name  |
 | -------- | ----- |
 | [String] | name  |
 | [String] | value |
 
-## ServiceItemListItem ([Structure])
+### ServiceItemListItem ([Structure])
 
 | Type                                                                  | Name                |
 | --------------------------------------------------------------------- | ------------------- |
@@ -448,7 +448,7 @@ Revision 1:
 | [ServiceItemLimitation](#serviceitemlimitation-structure)             | limitation          |
 | [List]&lt;[ServiceItemAttribute](#serviceitemattribute-structure)&gt; | attributes          |
 
-## ServiceItemCatalog ([Structure])
+### ServiceItemCatalog ([Structure])
 
 | Type                                                                | Name               |
 | ------------------------------------------------------------------- | ------------------ |
@@ -458,7 +458,7 @@ Revision 1:
 | Bool                                                                | isBalanceAvailable |
 | [ServiceItemAmount](#serviceitemamount-structure)                   | balance            |
 
-## ServiceItemListServiceItemResponse ([Structure])
+### ServiceItemListServiceItemResponse ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemEShopResponse](#serviceitemeshopresponse-structure)
 {: .prompt-info }
 
@@ -466,7 +466,7 @@ Revision 1:
 | ----------------------------------------------------------------- | --------------- |
 | [List]&lt;[ServiceItemCatalog](#serviceitemcatalog-structure)&gt; | nullableCatalog |
 
-## ServiceItemGetBalanceParam ([Structure])
+### ServiceItemGetBalanceParam ([Structure])
 
 | Type     | Name     |
 | -------- | -------- |
@@ -479,7 +479,7 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemGetBalanceResponse ([Structure])
+### ServiceItemGetBalanceResponse ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemEShopResponse](#serviceitemeshopresponse-structure)
 {: .prompt-info }
 
@@ -487,7 +487,7 @@ Revision 1:
 | --------------------------------------------------------------- | --------------- |
 | [List]&lt;[ServiceItemAmount](#serviceitemamount-structure)&gt; | nullableBalance |
 
-## ServiceItemGetPrepurchaseInfoParam ([Structure])
+### ServiceItemGetPrepurchaseInfoParam ([Structure])
 
 | Type                                                      | Name        |
 | --------------------------------------------------------- | ----------- |
@@ -503,7 +503,7 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemPrepurchaseRightInfo ([Structure])
+### ServiceItemPrepurchaseRightInfo ([Structure])
 
 | Type                 | Name           |
 | -------------------- | -------------- |
@@ -514,7 +514,7 @@ Revision 1:
 | Uint32               | expiredCount   |
 | [List]&lt;Uint32&gt; | expiryCounts   |
 
-## ServiceItemPrepurchaseInfo ([Structure])
+### ServiceItemPrepurchaseInfo ([Structure])
 
 | Type                                                                          | Name             |
 | ----------------------------------------------------------------------------- | ---------------- |
@@ -529,7 +529,7 @@ Revision 1:
 | [ServiceItemPrepurchaseRightInfo](#serviceitemprepurchaserightinfo-structure) | currentRightInfo |
 | [ServiceItemPrepurchaseRightInfo](#serviceitemprepurchaserightinfo-structure) | postRightInfo    |
 
-## ServiceItemGetPrepurchaseInfoResponse ([Structure])
+### ServiceItemGetPrepurchaseInfoResponse ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemEShopResponse](#serviceitemeshopresponse-structure)
 {: .prompt-info }
 
@@ -537,7 +537,7 @@ Revision 1:
 | --------------------------------------------------------------------------------- | ----------------------- |
 | [List]&lt;[ServiceItemPrepurchaseInfo](#serviceitemprepurchaseinfo-structure)&gt; | nullablePrepurchaseInfo |
 
-## ServiceItemGetServiceItemRightParam ([Structure])
+### ServiceItemGetServiceItemRightParam ([Structure])
 
 | Type     | Name        |
 | -------- | ----------- |
@@ -552,14 +552,14 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemRightBinary ([Structure])
+### ServiceItemRightBinary ([Structure])
 
 | Type      | Name        |
 | --------- | ----------- |
 | Uint8     | useType     |
 | [qBuffer] | rightBinary |
 
-## ServiceItemAccountRight ([Structure])
+### ServiceItemAccountRight ([Structure])
 
 | Type                                                                      | Name          |
 | ------------------------------------------------------------------------- | ------------- |
@@ -567,13 +567,13 @@ Revision 1:
 | [ServiceItemLimitation](#serviceitemlimitation-structure)                 | limitation    |
 | [List]&lt;[ServiceItemRightBinary](#serviceitemrightbinary-structure)&gt; | rightBinaries |
 
-## ServiceItemAccountRightTime ([Structure])
+### ServiceItemAccountRightTime ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemAccountRight](#serviceitemaccountright-structure)
 {: .prompt-info }
 
 This structure does not contain any fields.
 
-## ServiceItemAccountRightConsumption ([Structure])
+### ServiceItemAccountRightConsumption ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemAccountRight](#serviceitemaccountright-structure)
 {: .prompt-info }
 
@@ -583,30 +583,30 @@ This structure does not contain any fields.
 | Uint32               | expiredCount |
 | [List]&lt;Uint32&gt; | expiryCounts |
 
-## ServiceItemRightInfo ([Structure])
+### ServiceItemRightInfo ([Structure])
 
 | Type     | Name            |
 | -------- | --------------- |
 | [String] | referenceId     |
 | Uint32   | referenceIdType |
 
-## ServiceItemRightTimeInfo ([Structure])
-> This structure [inherits](/docs/nex/types#structure-inheritance) from [serviceitemaccountright](#ServiceItemRightInfo-structure)
+### ServiceItemRightTimeInfo ([Structure])
+> This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemRightInfo](#serviceitemrightinfo-structure)
 {: .prompt-info }
 
 | Type                                                                                | Name          |
 | ----------------------------------------------------------------------------------- | ------------- |
 | [List]&lt;[ServiceItemAccountRightTime](#serviceitemaccountrighttime-structure)&gt; | accountRights |
 
-## ServiceItemRightConsumptionInfo ([Structure])
-> This structure [inherits](/docs/nex/types#structure-inheritance) from [serviceitemaccountright](#ServiceItemRightInfo-structure)
+### ServiceItemRightConsumptionInfo ([Structure])
+> This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemRightInfo](#serviceitemrightinfo-structure)
 {: .prompt-info }
 
 | Type                                                                                              | Name          |
 | ------------------------------------------------------------------------------------------------- | ------------- |
 | [List]&lt;[ServiceItemAccountRightConsumption](#serviceitemaccountrightconsumption-structure)&gt; | accountRights |
 
-## ServiceItemRightInfos ([Structure])
+### ServiceItemRightInfos ([Structure])
 
 | Type                                                                                        | Name                            |
 | ------------------------------------------------------------------------------------------- | ------------------------------- |
@@ -616,7 +616,7 @@ This structure does not contain any fields.
 | [List]&lt;[ServiceItemRightTimeInfo](#serviceitemrighttimeinfo-structure)&gt;               | permanentRightInfos             |
 | Bool                                                                                        | alreadyPurchasedInitialOnlyItem |
 
-## ServiceItemGetServiceItemRightResponse ([Structure])
+### ServiceItemGetServiceItemRightResponse ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemEShopResponse](#serviceitemeshopresponse-structure)
 {: .prompt-info }
 
@@ -624,7 +624,7 @@ This structure does not contain any fields.
 | ----------------------------------------------------------------------- | ------------------ |
 | [List]&lt;[ServiceItemRightInfos](#serviceitemrightinfos-structure)&gt; | nullableRightInfos |
 
-## ServiceItemGetPurchaseHistoryParam ([Structure])
+### ServiceItemGetPurchaseHistoryParam ([Structure])
 
 | Type     | Name     |
 | -------- | -------- |
@@ -639,7 +639,7 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemTransaction ([Structure])
+### ServiceItemTransaction ([Structure])
 
 | Type                                                      | Name                   |
 | --------------------------------------------------------- | ---------------------- |
@@ -653,7 +653,7 @@ Revision 1:
 | [String]                                                  | referenceId            |
 | [ServiceItemLimitation](#serviceitemlimitation-structure) | limitation             |
 
-## ServiceItemPurchaseHistory ([Structure])
+### ServiceItemPurchaseHistory ([Structure])
 
 | Type                                                                      | Name         |
 | ------------------------------------------------------------------------- | ------------ |
@@ -661,7 +661,7 @@ Revision 1:
 | Uint32                                                                    | offset       |
 | [List]&lt;[ServiceItemTransaction](#serviceitemtransaction-structure)&gt; | transactions |
 
-## ServiceItemGetPurchaseHistoryResponse ([Structure])
+### ServiceItemGetPurchaseHistoryResponse ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemEShopResponse](#serviceitemeshopresponse-structure)
 {: .prompt-info }
 
@@ -669,14 +669,14 @@ Revision 1:
 | --------------------------------------------------------------------------------- | ----------------------- |
 | [List]&lt;[ServiceItemPurchaseHistory](#serviceitempurchasehistory-structure)&gt; | nullablePurchaseHistory |
 
-## ServiceItemLawMessage ([Structure])
+### ServiceItemLawMessage ([Structure])
 
 | Type     | Name              |
 | -------- | ----------------- |
 | Bool     | isMessageRequired |
 | [String] | lawMessage        |
 
-## ServiceItemGetLawMessageParam ([Structure])
+### ServiceItemGetLawMessageParam ([Structure])
 
 | Type     | Name     |
 | -------- | -------- |
@@ -689,7 +689,7 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemGetLawMessageResponse ([Structure])
+### ServiceItemGetLawMessageResponse ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemEShopResponse](#serviceitemeshopresponse-structure)
 {: .prompt-info }
 
@@ -697,7 +697,7 @@ Revision 1:
 | ----------------------------------------------------------------------- | ------------------ |
 | [List]&lt;[ServiceItemLawMessage](#serviceitemlawmessage-structure)&gt; | nullableLawMessage |
 
-## ServiceItemPostRightBinaryByAccountParam ([Structure])
+### ServiceItemPostRightBinaryByAccountParam ([Structure])
 
 | Type      | Name        |
 | --------- | ----------- |
@@ -713,13 +713,13 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemPostRightBinaryResponse ([Structure])
+### ServiceItemPostRightBinaryResponse ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemEShopResponse](#serviceitemeshopresponse-structure)
 {: .prompt-info }
 
 This structure does not contain any fields.
 
-## ServiceItemUseServiceItemByAccountParam ([Structure])
+### ServiceItemUseServiceItemByAccountParam ([Structure])
 
 | Type      | Name                      |
 | --------- | ------------------------- |
@@ -737,14 +737,14 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemUsedInfo ([Structure])
+### ServiceItemUsedInfo ([Structure])
 
 | Type   | Name          |
 | ------ | ------------- |
 | Uint32 | acquiredCount |
 | Uint32 | usedCount     |
 
-## ServiceItemUseServiceItemResponse ([Structure])
+### ServiceItemUseServiceItemResponse ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [ServiceItemEShopResponse](#serviceitemeshopresponse-structure)
 {: .prompt-info }
 
@@ -752,7 +752,7 @@ Revision 1:
 | ------------------------------------------------------------------- | ---------------- |
 | [List]&lt;[ServiceItemUsedInfo](#serviceitemusedinfo-structure)&gt; | nullableUsedInfo |
 
-## ServiceItemAcquireServiceItemByAccountParam ([Structure])
+### ServiceItemAcquireServiceItemByAccountParam ([Structure])
 
 | Type      | Name                      |
 | --------- | ------------------------- |
@@ -771,7 +771,7 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemAcquireServiceItemResponse ([Structure])
+### ServiceItemAcquireServiceItemResponse ([Structure])
 
 | Type                 | Name           |
 | -------------------- | -------------- |
@@ -782,7 +782,7 @@ Revision 1:
 | Uint32               | expiredCount   |
 | [List]&lt;Uint32&gt; | expiryCounts   |
 
-## ServiceItemGetSupportIdParam ([Structure])
+### ServiceItemGetSupportIdParam ([Structure])
 
 | Type   | Name     |
 | ------ | -------- |
@@ -794,13 +794,13 @@ Revision 1:
 | ----- | -------- |
 | Uint8 | platform |
 
-## ServiceItemGetNoticeParam ([Structure])
+### ServiceItemGetNoticeParam ([Structure])
 
 | Type   | Name         |
 | ------ | ------------ |
 | Uint32 | scheduleType |
 
-## ServiceItemNotice ([Structure])
+### ServiceItemNotice ([Structure])
 
 | Type       | Name         |
 | ---------- | ------------ |
@@ -812,7 +812,7 @@ Revision 1:
 | [DateTime] | timeBegin    |
 | [DateTime] | timeEnd      |
 
-## ServiceItemUserInfo ([Structure])
+### ServiceItemUserInfo ([Structure])
 
 | Type      | Name              |
 | --------- | ----------------- |

--- a/docs/nex/protocols/title-storage-admin.md
+++ b/docs/nex/protocols/title-storage-admin.md
@@ -1,0 +1,194 @@
+---
+layout: post
+toc: true
+title: Title Storage Admin
+---
+
+## Methods
+
+| Method ID | Method Name                                                                     |
+| --------- | ------------------------------------------------------------------------------- |
+| 1         | [GetContentTypesDescription](#1-getcontenttypesdescription)                     |
+| 2         | [GetContentTypeDescription](#2-getcontenttypedescription)                       |
+| 3         | [BrowseContents](#3-browsecontents)                                             |
+| 4         | [GetContentDetails](#4-getcontentdetails)                                       |
+| 5         | [CreateContentAndGetUploadInformation](#5-createcontentandgetuploadinformation) |
+| 6         | [RemoveContent](#6-removecontent)                                               |
+| 7         | [UpdateContentMetaData](#7-updatecontentmetadata)                               |
+| 8         | [ContentInsertionCompleted](#8-contentinsertioncompleted)                       |
+
+### (1) GetContentTypesDescription
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type                                                                          | Name                |
+| ----------------------------------------------------------------------------- | ------------------- |
+| [List]&#x3C;[ContentTypeDescription](#contenttypedescription-structure)&#x3E; | contentDescriptions |
+
+### (2) GetContentTypeDescription
+
+#### Request
+
+| Type     | Name        |
+| -------- | ----------- |
+| [String] | contentType |
+
+#### Response
+
+| Type                                                                                | Name            |
+| ----------------------------------------------------------------------------------- | --------------- |
+| [List]&#x3C;[ContentTypeExtensionField](#contenttypeextensionfield-structure)&#x3E; | extensionFields |
+
+### (3) BrowseContents
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type                                                                | Name     |
+| ------------------------------------------------------------------- | -------- |
+| [List]&#x3C;[AdminTitleContent](#admintitlecontent-structure)&#x3E; | contents |
+
+### (4) GetContentDetails
+
+#### Request
+
+| Type   | Name      |
+| ------ | --------- |
+| Uint32 | contentId |
+
+#### Response
+
+| Type   | Name    |
+| ------ | ------- |
+| [Data] | details |
+
+### (5) CreateContentAndGetUploadInformation
+
+#### Request
+
+| Type       | Name          |
+| ---------- | ------------- |
+| [String]   | name          |
+| [String]   | description   |
+| [String]   | key           |
+| [DateTime] | dateAvailable |
+| [DateTime] | dateExpired   |
+| Uint32     | flags         |
+| Uint32     | extendedFlags |
+| [String]   | contentType   |
+| [Data]     | extension     |
+| [String]   | mime          |
+
+#### Response
+
+| Type                               | Name           |
+| ---------------------------------- | -------------- |
+| Uint32                             | contentId      |
+| [String]                           | uploadURL      |
+| [String]                           | uploadMimeType |
+| [Map]&#x3C;[String],[String]&#x3E; | uploadBody     |
+
+### (6) RemoveContent
+
+#### Request
+
+| Type   | Name      |
+| ------ | --------- |
+| Uint32 | contentId |
+
+#### Response
+
+| Type | Name     |
+| ---- | -------- |
+| Bool | %retval% |
+
+### (7) UpdateContentMetaData
+
+#### Request
+
+| Type       | Name          |
+| ---------- | ------------- |
+| Uint32     | contentId     |
+| [String]   | name          |
+| [String]   | description   |
+| [DateTime] | dateAvailable |
+| [DateTime] | dateExpired   |
+| Uint32     | flags         |
+| Uint32     | extendedFlags |
+| [Data]     | extension     |
+
+#### Response
+
+| Type | Name     |
+| ---- | -------- |
+| Bool | %retval% |
+
+### (8) ContentInsertionCompleted
+
+#### Request
+
+| Type   | Name        |
+| ------ | ----------- |
+| Uint32 | contentId   |
+| Uint32 | contentSize |
+
+#### Response
+
+| Type | Name     |
+| ---- | -------- |
+| Bool | %retval% |
+
+## Types
+
+### ContentTypeExtensionField ([Structure])
+
+| Type     | Name        |
+| -------- | ----------- |
+| [String] | m_FieldName |
+| [String] | m_FieldType |
+
+### ContentTypeDescription ([Structure])
+
+| Type                                                                                | Name              |
+| ----------------------------------------------------------------------------------- | ----------------- |
+| [String]                                                                            | m_ContentType     |
+| [List]&#x3C;[ContentTypeExtensionField](#contenttypeextensionfield-structure)&#x3E; | m_extensionFields |
+
+### ContentDescription ([Structure])
+
+| Type     | Name                 |
+| -------- | -------------------- |
+| [String] | m_ContentDisplayName |
+| [String] | m_ContentDescription |
+
+### AdminTitleContent ([Structure])
+
+| Type                                                | Name                 |
+| --------------------------------------------------- | -------------------- |
+| Uint32                                              | m_id                 |
+| [String]                                            | m_name               |
+| [ContentDescription](#contentdescription-structure) | m_contentDescription |
+| Uint32                                              | m_flags              |
+| Uint32                                              | m_extendedFlags      |
+| [DateTime]                                          | m_dateAvailable      |
+| [DateTime]                                          | m_dateExpired        |
+| [String]                                            | m_contentType        |
+| [String]                                            | m_downloadURL        |
+
+[Result]: /docs/nex/types#result
+[String]: /docs/nex/types#string
+[Buffer]: /docs/nex/types#buffer
+[qBuffer]: /docs/nex/types#qbuffer
+[List]: /docs/nex/types#list
+[Map]: /docs/nex/types#map
+[DateTime]: /docs/nex/types#datetime
+[Structure]: /docs/nex/types#structure
+[Data]: /docs/nex/types#anydataholder
+[StationURL]: /docs/nex/types#stationurl
+[Variant]: /docs/nex/types#variant
+[PID]: /docs/nex/types#pid

--- a/docs/nex/protocols/title-storage.md
+++ b/docs/nex/protocols/title-storage.md
@@ -1,0 +1,108 @@
+---
+layout: post
+toc: true
+title: Title Storage (51)
+---
+
+## Methods
+
+| Method ID | Method Name                                     |
+| --------- | ----------------------------------------------- |
+| 1         | [BrowseContents](#1-browsecontents)             |
+| 2         | [BrowseContentsByType](#2-browsecontentsbytype) |
+| 3         | [GetContentDetails](#3-getcontentdetails)       |
+| 4         | [DownloadContent](#4-downloadcontent)           |
+
+### (1) BrowseContents
+
+#### Request
+
+| Type   | Name                  |
+| ------ | --------------------- |
+| Uint32 | flags                 |
+| Uint8  | flagsMaskType         |
+| Uint32 | extendedFlags         |
+| Uint8  | extendedFlagsMaskType |
+
+#### Response
+
+| Type                                                      | Name     |
+| --------------------------------------------------------- | -------- |
+| [List]&#x3C;[TitleContent](#titlecontent-structure)&#x3E; | contents |
+
+### (2) BrowseContentsByType
+
+#### Request
+
+| Type     | Name                  |
+| -------- | --------------------- |
+| [String] | contentType           |
+| Uint32   | flags                 |
+| Uint8    | flagsMaskType         |
+| Uint32   | extendedFlags         |
+| Uint8    | extendedFlagsMaskType |
+
+#### Response
+
+| Type                     | Name     |
+| ------------------------ | -------- |
+| [List]&#x3C;[Data]&#x3E; | contents |
+
+### (3) GetContentDetails
+
+#### Request
+
+| Type   | Name      |
+| ------ | --------- |
+| Uint32 | contentID |
+
+#### Response
+
+| Type   | Name    |
+| ------ | ------- |
+| [Data] | details |
+
+### (4) DownloadContent
+
+#### Request
+
+| Type   | Name      |
+| ------ | --------- |
+| Uint32 | contentID |
+
+#### Response
+
+| Type     | Name  |
+| -------- | ----- |
+| [String] | proto |
+| [String] | host  |
+| [String] | path  |
+
+## Types
+
+### TitleContent ([Structure])
+> This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
+{: .prompt-info }
+
+| Type     | Name          |
+| -------- | ------------- |
+| Uint32   | id            |
+| [String] | name          |
+| [String] | description   |
+| Sint64   | size          |
+| [String] | contentType   |
+| Uint32   | flags         |
+| Uint32   | extendedFlags |
+
+[Result]: /docs/nex/types#result
+[String]: /docs/nex/types#string
+[Buffer]: /docs/nex/types#buffer
+[qBuffer]: /docs/nex/types#qbuffer
+[List]: /docs/nex/types#list
+[Map]: /docs/nex/types#map
+[DateTime]: /docs/nex/types#datetime
+[Structure]: /docs/nex/types#structure
+[Data]: /docs/nex/types#anydataholder
+[StationURL]: /docs/nex/types#stationurl
+[Variant]: /docs/nex/types#variant
+[PID]: /docs/nex/types#pid

--- a/docs/nex/protocols/user-storage-admin.md
+++ b/docs/nex/protocols/user-storage-admin.md
@@ -29,17 +29,17 @@ title: User Storage Admin
 
 #### Response
 
-| Type                                                                     | Name         |
-| ------------------------------------------------------------------------ | ------------ |
-| [List]&lt;[UserContent](/protocols/nex/protocols/user-content#usercontent-structure)&gt; | contents     |
-| Uint32                                                                   | totalResults |
+| Type                                                            | Name         |
+| --------------------------------------------------------------- | ------------ |
+| [List]&lt;[UserContent](user-storage#usercontent-structure)&gt; | contents     |
+| Uint32                                                          | totalResults |
 
 ### (2) FlagContentAsVerified
 #### Request
 
-| Type                                                             | Name       |
-| ---------------------------------------------------------------- | ---------- |
-| [UserContentKey](/protocols/nex/protocols/user-content#usercontentkey-structure) | contentKey |
+| Type                                                    | Name       |
+| ------------------------------------------------------- | ---------- |
+| [UserContentKey](user-storage#usercontentkey-structure) | contentKey |
 
 #### Response
 This method does not return anything.
@@ -47,9 +47,9 @@ This method does not return anything.
 ### (3) BanContent
 #### Request
 
-| Type                                                             | Name       |
-| ---------------------------------------------------------------- | ---------- |
-| [UserContentKey](/protocols/nex/protocols/user-content#usercontentkey-structure) | contentKey |
+| Type                                                    | Name       |
+| ------------------------------------------------------- | ---------- |
+| [UserContentKey](user-storage#usercontentkey-structure) | contentKey |
 
 #### Response
 This method does not return anything.
@@ -114,18 +114,18 @@ This method does not return anything.
 
 #### Response
 
-| Type                                                                     | Name         |
-| ------------------------------------------------------------------------ | ------------ |
-| [List]&lt;[UserContent](/protocols/nex/protocols/user-content#usercontent-structure)&gt; | contents     |
-| Uint32                                                                   | totalResults |
+| Type                                                            | Name         |
+| --------------------------------------------------------------- | ------------ |
+| [List]&lt;[UserContent](user-storage#usercontent-structure)&gt; | contents     |
+| Uint32                                                          | totalResults |
 
 ### (9) UpdateMetaData
 #### Request
 
-| Type                                                                             | Name       |
-| -------------------------------------------------------------------------------- | ---------- |
-| [UserContentKey](/protocols/nex/protocols/user-content#usercontentkey-structure)                 | contentKey |
-| [List]&lt;[ContentProperty](/protocols/nex/protocols/user-content#contentproperty-structure)&gt; | properties |
+| Type                                                                    | Name       |
+| ----------------------------------------------------------------------- | ---------- |
+| [UserContentKey](user-storage#usercontentkey-structure)                 | contentKey |
+| [List]&lt;[ContentProperty](user-storage#contentproperty-structure)&gt; | properties |
 
 #### Response
 This method does not return anything.

--- a/docs/switch/baas.md
+++ b/docs/switch/baas.md
@@ -49,7 +49,7 @@ The user agents below are taken from the account sysmodule. If the request is ma
 | 13.1.0 - 13.2.1 | `libcurl (nnAccount; 789f928b-138e-4b2f-afeb-1acae821d897; SDK 13.4.0.0; Add-on 13.4.0.0)` |
 | 14.0.0 - 14.1.2 | `libcurl (nnAccount; 789f928b-138e-4b2f-afeb-1acae821d897; SDK 14.3.0.0; Add-on 14.3.0.0)` |
 | 15.0.0 - 15.0.1 | `libcurl (nnAccount; 789f928b-138e-4b2f-afeb-1acae821d897; SDK 15.3.0.0; Add-on 15.3.0.0)` |
-| 16.0.0          | `libcurl (nnAccount; 789f928b-138e-4b2f-afeb-1acae821d897; SDK 16.2.0.0; Add-on 16.2.0.0)` |
+| 16.0.0 - 16.0.2 | `libcurl (nnAccount; 789f928b-138e-4b2f-afeb-1acae821d897; SDK 16.2.0.0; Add-on 16.2.0.0)` |
 
 ## Methods
 The following methods do not require an access token:

--- a/docs/switch/dauth.md
+++ b/docs/switch/dauth.md
@@ -49,7 +49,7 @@ The X-Nintendo-PowerState header is only present on system version 7.0.0 and lat
 | 13.1.0 - 13.2.1 | `libcurl (nnDauth; 16f4553f-9eee-4e39-9b61-59bc7c99b7c8; SDK 13.4.0.0)`                      |
 | 14.0.0 - 14.1.2 | `libcurl (nnDauth; 16f4553f-9eee-4e39-9b61-59bc7c99b7c8; SDK 14.3.0.0)`                      |
 | 15.0.0 - 15.0.1 | `libcurl (nnDauth; 16f4553f-9eee-4e39-9b61-59bc7c99b7c8; SDK 15.3.0.0)`                      |
-| 16.0.0          | `libcurl (nnDauth; 16f4553f-9eee-4e39-9b61-59bc7c99b7c8; SDK 16.2.0.0)`                      |
+| 16.0.0 - 16.0.2 | `libcurl (nnDauth; 16f4553f-9eee-4e39-9b61-59bc7c99b7c8; SDK 16.2.0.0)`                      |
 
 ## Methods
 In API version 3 and later, one must perform a cryptographic challenge to obtain a device token or edge token:
@@ -94,7 +94,7 @@ The following methods return a different kind of device token:
 | 6.2.0           | v4  |
 | 7.0.0 - 8.1.1   | v5  |
 | 9.0.0 - 12.1.0  | v6  |
-| 13.0.0 - 16.0.0 | v7  |
+| 13.0.0 - 16.0.2 | v7  |
 
 #### API Changes
 
@@ -207,7 +207,7 @@ A `vendor_id` parameter was added:
 | 13.0.0 - 13.2.1 | 13             |
 | 14.0.0 - 14.1.2 | 14             |
 | 15.0.0 - 15.0.1 | 15             |
-| 16.0.0          | 16             |
+| 16.0.0 - 16.0.2 | 16             |
 
 ## Known Client IDs
 


### PR DESCRIPTION
- Add versioning to some DataStore and MatchMaking fields (the same as from the PR for `nex-protocols-go`)
- Add missing notifiaction types (the same as from the PR for `nex-protocols-go`)
- Fix docs formatting issues to make some tables visible and make header size consistent on Service Item
- Document some unknown fields on Friends (3DS), as we know what are their contents. Also add the real name of the fields of the `GameKey` structure.
- Add some undocumented Rendez-Vous protocols that appear on Rayman Legends Challenges App:
  - Title Storage
  - Title Storage Admin
  - OLS Storage (this one seems to be a custom protocol for Rayman Legends, guessing from the name of some fields)
- Update the wiki to add latest changes made by Kinnay