### PR TITLE
Fix docs formatting issues and DataStoreSearchParam versioning

### DIFF
--- a/docs/3ds/nasc.md
+++ b/docs/3ds/nasc.md
@@ -115,6 +115,7 @@ On error, the server sends the following response:
 Sometimes, `returncd` is set to `null` instead of an error code.
 
 ### Known Errors
+
 | Code  | Description                               |
 |-------|-------------------------------------------|
 | `001` | Success                                   |

--- a/docs/nex/protocols/datastore/index.md
+++ b/docs/nex/protocols/datastore/index.md
@@ -956,18 +956,43 @@ In NEX version 3.5, one more field was added:
 | Uint8                  | resultOption           |
 | Uint32                 | minimalRatingFrequency |
 
-In NEX version 3.5, one more field was added:
+Revision 1:
 
-| Type                   | Name                   |
-| ---------------------- | ---------------------- |
-| Bool                   | useCache               |
+| Type | Name     |
+| ---- | -------- |
+| Bool | useCache |
 
-Only present on Switch:
+Revision 2:
 
 | Type                 | Name              |
 | -------------------- | ----------------- |
-| Bool                 | totalCountEnabled |
 | [List]&lt;Uint16&gt; | dataTypes         |
+
+In revision 3, a total count enabled field was added. Note that this field was inserted before the data types field:
+
+| Type                   | Name                   |
+| ---------------------- | ---------------------- |
+| Uint8                  | searchTarget           |
+| [List]&lt;[PID]&gt;    | ownerIds               |
+| Uint8                  | ownerType              |
+| [List]&lt;Uint64&gt;   | destinationIds         |
+| Uint16                 | dataType               |
+| [DateTime]             | createdAfter           |
+| [DateTime]             | createdBefore          |
+| [DateTime]             | updatedAfter           |
+| [DateTime]             | updatedBefore          |
+| Uint32                 | referDataId            |
+| [List]&lt;[String]&gt; | tags                   |
+| Uint8                  | resultOrderColumn      |
+| Uint8                  | resultOrder            |
+| [ResultRange]          | resultRange            |
+| Uint8                  | resultOption           |
+| Uint32                 | minimalRatingFrequency |
+| Bool                   | useCache               |
+| Bool                   | totalCountEnabled      |
+| [List]&lt;Uint16&gt;   | dataTypes              |
+
+In NEX version 4.0, the revision number was set back to 0 with no other changes.
 
 ### DataStoreSearchResult ([Structure])
 
@@ -976,6 +1001,14 @@ Only present on Switch:
 | Uint32                            | totalCount     |
 | [List]&lt;[DataStoreMetaInfo]&gt; | result         |
 | Uint8                             | totalCountType |
+
+Total count types:
+
+| Type   | Description                                               |
+| ------ | --------------------------------------------------------- |
+| 0      | Total number of results (if all results are returned)     |
+| 1      | Total number of results (if not all results are returned) |
+| 3      | Disabled                                                  |
 
 ### DataStoreGetNotificationUrlParam ([Structure])
 

--- a/docs/nex/protocols/notifications.md
+++ b/docs/nex/protocols/notifications.md
@@ -34,7 +34,7 @@ Most notification types are predefined. However, some games also implement their
 | Uint32   | m_uiParam2  |
 | [String] | m_strParam  |
 
-In NEX version 3.5, a new field was added:
+In NEX version 3.4, a new field was added:
 
 | Type     | Name       |
 | -------- | ---------- |

--- a/docs/nex/protocols/secure-connection/nintendo-badge-arcade.md
+++ b/docs/nex/protocols/secure-connection/nintendo-badge-arcade.md
@@ -8,9 +8,9 @@ This page describes the methods that are only seen in Nintendo Badge Arcade.
 
 ## Methods
 
-| Method ID | Name                 |
-| --------- | -------------------- |
-| 9         | GetMaintenanceStatus |
+| Method ID | Name                                            |
+| --------- | ----------------------------------------------- |
+| 9         | [GetMaintenanceStatus](#9-getmaintenancestatus) |
 
 ## (9) GetMaintenanceStatus
 ### Request

--- a/docs/pia/enl/index.md
+++ b/docs/pia/enl/index.md
@@ -11,6 +11,7 @@ To transmit game-data, games can register content transporters to ENL. ENL also 
 A message consists of one or more records, terminated by a record with type 255. No byte swapping is done on the fields. The endianness depends on the system.
 
 ## Record Header
+
 | Type   | Description |
 |--------|-------------|
 | Uint8  | Record type |

--- a/docs/pia/index.md
+++ b/docs/pia/index.md
@@ -35,7 +35,7 @@ All peer-to-peer packets are sent through UDP. The packet format is described [h
 * [Unreliable Protocol](/docs/pia/protocols/unreliable)
 * [Reliable Protocol](/docs/pia/protocols/reliable)
 * Stream Broadcast Reliable Protocol
-* (Clone Protocol)[/docs/pia/protocols/clone]
+* [Clone Protocol](/docs/pia/protocols/clone)
 * Sync Protocol
 
 ### Session management

--- a/docs/pia/lan.md
+++ b/docs/pia/lan.md
@@ -70,6 +70,7 @@ These flags indicate which fields are compared against the active session to det
 | 0x800 | Last attribute list            |
 
 #### Range
+
 | Offset | Size | Description |
 | ------ | ---- | ----------- |
 | 0x0    | 2    | Maximum     |

--- a/docs/pia/protocols/index.md
+++ b/docs/pia/protocols/index.md
@@ -40,7 +40,7 @@ Also, the clone protocol used to be single protocol, but was split into several 
 |        | 0x80        | Broadcast Reliable Protocol                                     |
 |        | 0x81        | Stream Broadcast Reliable Protocol                              |
 | 0x7000 | 0x84        | Reliable Broadcast Protocol                                     |
-| 0x7200 | 0x94        | [[Session Protocol]]                                            |
+| 0x7200 | 0x94        | [Session Protocol](/docs/pia/protocols/session)                 |
 |        | 0x98        | Lobby Protocol                                                  |
 |        | 0xA0        | NAT Traversal Result Protocol                                   |
 | 0x8000 | 0xA4        | [Monitoring Data Protocol](/docs/pia/protocols/monitoring-data) |


### PR DESCRIPTION
## Additions

- Add list of total count types for `DataStoreSearchResult`

## Changes

- Fix docs formatting issues
- Drop m_uiParam3 to NEX version 3.4
- Update `DataStoreSearchParam` with proper versioning and structure revisions