### PR TITLE
Update FriendPersistentInfo for 3DS

### DIFF
--- a/docs/nex/protocols/friends-3ds.md
+++ b/docs/nex/protocols/friends-3ds.md
@@ -396,7 +396,7 @@ This method does not return anything
 | [GameKey](#gamekey-structure) | Game key           |
 | [String]                      | Message            |
 | [DateTime]                    | Message updated at |
-| [DateTime]                    | Friended at        |
+| [DateTime]                    | Mii modified at    |
 | [DateTime]                    | Last online at     |
 
 ### FriendPicture ([Structure])


### PR DESCRIPTION
One of the DateTimes doesn't represent the date of the friendship, but when the friend has updated their Mii.

I noticed this when playing with the friend servers researching information about the data stored in the FRD sysmodule.

I will submit PRs to nex-protocols-go and the friends server to fix the inaccuracy.