### PR TITLE
Update documentation regarding RMC and structure version encoding

### DIFF
--- a/docs/nex/types.md
+++ b/docs/nex/types.md
@@ -125,7 +125,6 @@ A variant consists of an uint8 indicating the type followed by its value.
 | 6       | Uint64     |
 
 ## Structure
-
 When using the ["verbose" RMC variation](/docs/rmc) the structure version information is stored in the [ClassVersionContainer](/docs/rmc#classversioncontainer). When using the ["packed" RMC variation](/docs/rmc), and the client is using NEX v3.5.0 or above, the structures version information is encoded as a header before the structures contents. Before NEX v3.5.0, the structures contents are encoded directly into the stream without a version header
 
 ### Structure header

--- a/docs/nex/types.md
+++ b/docs/nex/types.md
@@ -125,7 +125,10 @@ A variant consists of an uint8 indicating the type followed by its value.
 | 6       | Uint64     |
 
 ## Structure
-NEX v3.5.0 introduced a versioning system to structures. Before v3.5.0 their contents were just normally stored into the stream. However, starting with v3.5.0, structures are stored like this:
+
+When using the ["verbose" RMC variation](/docs/rmc) the structure version information is stored in the [ClassVersionContainer](/docs/rmc#classversioncontainer). When using the ["packed" RMC variation](/docs/rmc), and the client is using NEX v3.5.0 or above, the structures version information is encoded as a header before the structures contents. Before NEX v3.5.0, the structures contents are encoded directly into the stream without a version header
+
+### Structure header
 
 | Type   | Description    |
 | ------ | -------------- |

--- a/docs/rmc.md
+++ b/docs/rmc.md
@@ -5,7 +5,7 @@ title: RMC Protocol
 ---
 
 # Overview
-[PRUDP](/docs/prudp) packets may have optional payloads. These payloads may be anything, however typically `DATA` packets use RMC. RMC is a standardized protocol for calling methods on remote services. RMC has been known to come in at least 3 different variations. The variation used is already know to both the server and client. These variations are:
+[PRUDP](/docs/prudp) packets may have optional payloads. These payloads may be anything, however typically `DATA` packets use RMC. RMC, presumably standing for "Remote Method Call", is a standardized protocol for calling methods on remote services. RMC has been known to come in at least 3 different variations. The variation used is already know to both the server and client. These variations are:
 
 - "Packed" - Information about the service and method is tightly packed, such as using integers for protocol/method IDs
 - "Packed" extended - The exact same as the previous "packed" variation, except an additional uint16 is added as the "true" protocol ID. In this case the uint8 "protocol ID" is `0x7F`

--- a/docs/rmc.md
+++ b/docs/rmc.md
@@ -93,7 +93,7 @@ In all known cases, the method name string in responses ends with a `*`. Looking
 
 ## ClassVersionContainer
 
-The `ClassVersionContainer` is a [List](/docs/nex/types#list) of `ClassVersion` types. Unlike in the "packed" variations, where structure version information is optionally stored as a header on the structure, a `ClassVersion` defines this version only once before the rest of the message is parsed. Presumably this is done to not re-encode the same version information multiple times, though the cases where this is beneficial are few. Every *request* in the "verbose" variation begins with a `ClassVersionContainer`, even if it has 0 elements. Responses do not use a `ClassVersionContainer`, nor do they encode the structure header
+The `ClassVersionContainer` is a [List](/docs/nex/types#list) of [ClassVersion](#classversion) types. Unlike in the "packed" variations, where structure version information is optionally stored as a header on the structure, a [ClassVersion](#classversion) defines this version only once before the rest of the message is parsed. Presumably this is done to not re-encode the same version information multiple times, though the cases where this is beneficial are few. Every *request* in the "verbose" variation begins with a `ClassVersionContainer`, even if it has 0 elements. Responses do not use a `ClassVersionContainer`, nor do they encode the structure header
 
 ## ClassVersion
 

--- a/docs/rmc.md
+++ b/docs/rmc.md
@@ -4,32 +4,42 @@ toc: true
 title: RMC Protocol
 ---
 
-This is a simple remote method call protocol that lies on top of the [PRUDP protocol](/docs/prudp).
+# Overview
+
+[PRUDP](/docs/prudp) packets may have optional payloads. These payloads may be anything, however typically `DATA` packets use RMC. RMC is a standardized protocol for calling methods on remote services. RMC has been known to come in at least 3 different variations. The variation used is already know to both the server and client. These variations are:
+
+- "Packed" - Information about the service and method is tightly packed, such as using integers for protocol/method IDs
+- "Packed" extended - The exact same as the previous "packed" variation, except an additional uint16 is added as the "true" protocol ID. In this case the uint8 "protocol ID" is `0x7F`
+- "Verbose" - Rather than tightly packing data, this variation opts to encode information about the remote service and method in a more verbose way, using strings in place of integer IDs. This variation also changes how [Structures](/docs/nex/types#structure) are encoded
+
+All NEX titles use one of the "packed" variations. Many Rendez-Vous titles also seem to use the "packed" variations. However some Rendez-Vous titles, such as Watch Dogs for the Wii U, use the "verbose" variation
+
+# "Packed" variations
 
 ## Request Format
 
-| Type   | Description                                                                   |
-| ------ | ----------------------------------------------------------------------------- |
-| Uint32 | Size, excluding this field                                                    |
-| Uint8  | [Protocol id](/docs/nex/protocols), ORed with 0x80                            |
-| Uint16 | Extended protocol id. **Only present if the protocol id is 0x7F.**            |
-| Uint32 | Call id, an incrementing number used to match a response to the right request |
-| Uint32 | Method id                                                                     |
-| ...    | Method parameters                                                             |
+| Type   | Description                                                                                     |
+|--------|-------------------------------------------------------------------------------------------------|
+| Uint32 | Size, excluding this field                                                                      |
+| Uint8  | [Protocol id](/docs/nex/protocols), ORed with 0x80                                              |
+| Uint16 | Extended protocol id. **Only present if using the "extended" variation (protocol id is 0x7F).** |
+| Uint32 | Call id, an incrementing number used to match a response to the right request                   |
+| Uint32 | Method id                                                                                       |
+| ...    | Method parameters                                                                               |
 
 ## Response Format
 
 | Type   | Description                                                        |
-| ------ | ------------------------------------------------------------------ |
+|--------|--------------------------------------------------------------------|
 | Uint32 | Size, excluding this field                                         |
 | Uint8  | [Protocol id](/docs/nex/protocols)                                 |
 | Uint16 | Extended protocol id. **Only present if the protocol id is 0x7F.** |
-| Uint8  | 0=Error 1=Success                                                  |
+| Bool  | "Is success"                                                  |
 
 **On success:**
 
 | Type   | Description                 |
-| ------ | --------------------------- |
+|--------|-----------------------------|
 | Uint32 | Call id                     |
 | Uint32 | Method id, ORed with 0x8000 |
 | ...    | Response data               |
@@ -37,11 +47,62 @@ This is a simple remote method call protocol that lies on top of the [PRUDP prot
 **On error:**
 
 | Type   | Description                                                                                               |
-| ------ | --------------------------------------------------------------------------------------------------------- |
+|--------|-----------------------------------------------------------------------------------------------------------|
 | Uint32 | Error code, see [errors.py](https://github.com/Kinnay/NintendoClients/blob/master/nintendo/nex/errors.py) |
 | Uint32 | Call id                                                                                                   |
 
-## Remarks
+# "Verbose" variation
+
+## Request Format
+
+| Type                                            | Description                                                                       |
+|-------------------------------------------------|-----------------------------------------------------------------------------------|
+| Uint32                                          | Size, excluding this field                                                        |
+| [String](/docs/nex/types#string)                | Protocol name                                                                     |
+| Bool                                            | "Is request" (true)                                                               |
+| Uint32                                          | Call id, an incrementing number used to match a response to the right request     |
+| [String](/docs/nex/types#string)                | Method name, with the protocol name as a prefix                                   |
+| [ClassVersionContainer](#classversioncontainer) | Information about the [Structures](/docs/nex/types#structure) used in the request |
+| ...                                             | Method parameters                                                                 |
+
+## Response Format
+
+| Type                             | Description                |
+|----------------------------------|----------------------------|
+| Uint32                           | Size, excluding this field |
+| [String](/docs/nex/types#string) | Protocol name              |
+| Bool                             | "Is request" (false)       |
+| Bool                             | "Is success"               |
+
+**On success:**
+
+| Type                             | Description                                     |
+|----------------------------------|-------------------------------------------------|
+| Uint32                           | Call id                                         |
+| [String](/docs/nex/types#string) | Method name, with the protocol name as a prefix |
+| ...                              | Response data                                   |
+
+In all known cases, the method name string in responses ends with a `*`. Looking at the response handlers for Watch Dogs on the Wii U, this seems to be related to a "return value pointer", though it is not entirely clear at this time
+
+**On error:**
+
+| Type   | Description                                                                                               |
+|--------|-----------------------------------------------------------------------------------------------------------|
+| Uint32 | Error code, see [errors.py](https://github.com/Kinnay/NintendoClients/blob/master/nintendo/nex/errors.py) |
+| Uint32 | Call id                                                                                                   |
+
+## ClassVersionContainer
+
+The `ClassVersionContainer` is a [List](/docs/nex/types#list) of `ClassVersion` types. Unlike in the "packed" variations, where structure version information is optionally stored as a header on the structure, a `ClassVersion` defines this version only once before the rest of the message is parsed. Presumably this is done to not re-encode the same version information multiple times, though the cases where this is beneficial are few. Every *request* in the "verbose" variation begins with a `ClassVersionContainer`, even if it has 0 elements. Responses do not use a `ClassVersionContainer`, nor do they encode the structure header
+
+## ClassVersion
+
+| Type                             | Description       |
+|----------------------------------|-------------------|
+| [String](/docs/nex/types#string) | Structure name    |
+| Uint16                           | Structure version |
+
+# Remarks
 The following services never send an RMC response, even if an error occurred:
 
 * [Notification Protocol](/docs/nex/protocols/notifications)

--- a/docs/rmc.md
+++ b/docs/rmc.md
@@ -12,7 +12,7 @@ title: RMC Protocol
 - "Packed" extended - The exact same as the previous "packed" variation, except an additional uint16 is added as the "true" protocol ID. In this case the uint8 "protocol ID" is `0x7F`
 - "Verbose" - Rather than tightly packing data, this variation opts to encode information about the remote service and method in a more verbose way, using strings in place of integer IDs. This variation also changes how [Structures](/docs/nex/types#structure) are encoded
 
-All NEX titles use one of the "packed" variations. Many Rendez-Vous titles also seem to use the "packed" variations. However some Rendez-Vous titles, such as Watch Dogs for the Wii U, use the "verbose" variation
+All NEX titles use one of the "packed" variations. Many Rendez-Vous titles also seem to use the "packed" variations. However, some Rendez-Vous titles use the "verbose" variation
 
 # "Packed" variations
 

--- a/docs/rmc.md
+++ b/docs/rmc.md
@@ -5,7 +5,6 @@ title: RMC Protocol
 ---
 
 # Overview
-
 [PRUDP](/docs/prudp) packets may have optional payloads. These payloads may be anything, however typically `DATA` packets use RMC. RMC is a standardized protocol for calling methods on remote services. RMC has been known to come in at least 3 different variations. The variation used is already know to both the server and client. These variations are:
 
 - "Packed" - Information about the service and method is tightly packed, such as using integers for protocol/method IDs
@@ -92,7 +91,6 @@ In all known cases, the method name string in responses ends with a `*`. Looking
 | Uint32 | Call id                                                                                                   |
 
 ## ClassVersionContainer
-
 The `ClassVersionContainer` is a [List](/docs/nex/types#list) of [ClassVersion](#classversion) types. Unlike in the "packed" variations, where structure version information is optionally stored as a header on the structure, a [ClassVersion](#classversion) defines this version only once before the rest of the message is parsed. Presumably this is done to not re-encode the same version information multiple times, though the cases where this is beneficial are few. Every *request* in the "verbose" variation begins with a `ClassVersionContainer`, even if it has 0 elements. Responses do not use a `ClassVersionContainer`, nor do they encode the structure header
 
 ## ClassVersion

--- a/docs/rmc.md
+++ b/docs/rmc.md
@@ -34,7 +34,7 @@ All NEX titles use one of the "packed" variations. Many Rendez-Vous titles also 
 | Uint32 | Size, excluding this field                                         |
 | Uint8  | [Protocol id](/docs/nex/protocols)                                 |
 | Uint16 | Extended protocol id. **Only present if the protocol id is 0x7F.** |
-| Bool  | "Is success"                                                  |
+| Bool   | "Is success"                                                       |
 
 **On success:**
 

--- a/docs/rmc.md
+++ b/docs/rmc.md
@@ -82,7 +82,7 @@ All NEX titles use one of the "packed" variations. Many Rendez-Vous titles also 
 | [String](/docs/nex/types#string) | Method name, with the protocol name as a prefix |
 | ...                              | Response data                                   |
 
-In all known cases, the method name string in responses ends with a `*`. Looking at the response handlers for Watch Dogs on the Wii U, this seems to be related to a "return value pointer", though it is not entirely clear at this time
+In all known cases, the method name string in responses ends with a `*`. Looking at the response handlers for some games, this seems to be related to a "return value pointer", though it is not entirely clear at this time
 
 **On error:**
 


### PR DESCRIPTION
Not all clients use the same "packed" RMC variation. PR adds documentation about the "verbose" variation seen in Watch Dogs (and potentially other QRV titles), as well as updates some documentation regarding structure version encoding as the "verbose" RMC variation changes this