### PR TITLE
DataStore ` modifiesFlag` docs

### DIFF
--- a/docs/nex/protocols/datastore/index.md
+++ b/docs/nex/protocols/datastore/index.md
@@ -1246,7 +1246,7 @@ In DataStore `modifiesFlag` is a set of flags which determine what data gets upd
 | `0x200` | Update objects `status` field. Anything besides `0` seems to result in `DataStore::NotFound` on future requests |
 
 ### Period
-DataStore objects are really just S3 objects. The `period` field of an object is the number of *days* the object is valid for before it expires and is deleted from S3. Objects can be "refreshed" to update their expire time, which also updates the objects `updatedTime` field. Not all games respect this value, however, and will either set their own expire time or never expire objects even if a `period` is set for them
+DataStore objects are really just S3 objects. The `period` field of an object is the number of *days* the object is valid for before it expires and is deleted from S3. Objects can be "refreshed" to update their expire time, which also updates the objects `updatedTime` field. Not all games respect this value, however, and will either set their own expire time or never expire objects even if a `period` is set for them.
 
 [Result]: /docs/nex/types#result
 [String]: /docs/nex/types#string

--- a/docs/nex/protocols/datastore/index.md
+++ b/docs/nex/protocols/datastore/index.md
@@ -743,7 +743,7 @@ In NEX version 3.5, one more field was added:
 | [DataStorePermission]                            | permission       |
 | [DataStorePermission]                            | delPermission    |
 | Uint32                                           | flag             |
-| Uint16                                           | period           |
+| Uint16                                           | [period](#period)           |
 | Uint32                                           | referDataId      |
 | [List]&lt;[String]&gt;                           | tags             |
 | [List]&lt;[DataStoreRatingInitParamWithSlot]&gt; | ratingInitParams |
@@ -759,7 +759,7 @@ In NEX version 3.5, one more field was added:
 | [DataStorePermission]                            | permission           |
 | [DataStorePermission]                            | delPermission        |
 | Uint32                                           | flag                 |
-| Uint16                                           | period               |
+| Uint16                                           | [period](#period)    |
 | Uint32                                           | referDataId          |
 | [List]&lt;[String]&gt;                           | tags                 |
 | [List]&lt;[DataStoreRatingInitParamWithSlot]&gt; | ratingInitParams     |
@@ -821,7 +821,7 @@ In NEX version 3.5, one more field was added:
 | [String]               | name                           |
 | [DataStorePermission]  | permission                     |
 | [DataStorePermission]  | delPermission                  |
-| Uint16                 | period                         |
+| Uint16                 | [period](#period)                         |
 | [qBuffer]              | metaBinary                     |
 | [List]&lt;[String]&gt; | tags                           |
 | Uint64                 | updatePassword                 |
@@ -835,7 +835,7 @@ In NEX version 3.5, one more field was added:
 | [String]                          | name                           |
 | [DataStorePermission]             | permission                     |
 | [DataStorePermission]             | delPermission                  |
-| Uint16                            | period                         |
+| Uint16                            | [period](#period)                         |
 | [qBuffer]                         | metaBinary                     |
 | [List]&lt;[String]&gt;            | tags                           |
 | Uint64                            | updatePassword                 |
@@ -888,7 +888,7 @@ Revision 1:
 | [DataStorePermission]                       | delPermission |
 | [DateTime]                                  | createdTime   |
 | [DateTime]                                  | updatedTime   |
-| Uint16                                      | period        |
+| Uint16                                      | [period](#period)        |
 | Uint8                                       | status        |
 | Uint32                                      | referredCnt   |
 | Uint32                                      | referDataId   |
@@ -1200,7 +1200,7 @@ Permission types:
 | [String]               | name           |
 | [DataStorePermission]  | permission     |
 | [DataStorePermission]  | delPermission  |
-| Uint16                 | period         |
+| Uint16                 | [period](#period)         |
 | [qBuffer]              | metaBinary     |
 | [List]&lt;[String]&gt; | tags           |
 | Uint32                 | referredCnt    |
@@ -1244,6 +1244,9 @@ In DataStore `modifiesFlag` is a set of flags which determine what data gets upd
 | `0x080` | Update objects `name` field                                                                                     |
 | `0x100` | Update objects `referredCnt` field. Set, not added                                                              |
 | `0x200` | Update objects `status` field. Anything besides `0` seems to result in `DataStore::NotFound` on future requests |
+
+### Period
+DataStore objects are really just S3 objects. The `period` field of an object is the number of *days* the object is valid for before it expires and is deleted from S3. Objects can be "refreshed" to update their expire time, which also updates the objects `updatedTime` field. Not all games respect this value, however, and will either set their own expire time or never expire objects even if a `period` is set for them
 
 [Result]: /docs/nex/types#result
 [String]: /docs/nex/types#string

--- a/docs/nex/protocols/datastore/index.md
+++ b/docs/nex/protocols/datastore/index.md
@@ -814,35 +814,35 @@ In NEX version 3.5, one more field was added:
 
 ### DataStoreChangeMetaParamV1 ([Structure])
 
-| Type                   | Name           |
-|------------------------|----------------|
-| Uint64                 | dataId         |
-| Uint32                 | modifiesFlag   |
-| [String]               | name           |
-| [DataStorePermission]  | permission     |
-| [DataStorePermission]  | delPermission  |
-| Uint16                 | period         |
-| [qBuffer]              | metaBinary     |
-| [List]&lt;[String]&gt; | tags           |
-| Uint64                 | updatePassword |
+| Type                   | Name                           |
+|------------------------|--------------------------------|
+| Uint64                 | dataId                         |
+| Uint32                 | [modifiesFlag](#modifies-flag) |
+| [String]               | name                           |
+| [DataStorePermission]  | permission                     |
+| [DataStorePermission]  | delPermission                  |
+| Uint16                 | period                         |
+| [qBuffer]              | metaBinary                     |
+| [List]&lt;[String]&gt; | tags                           |
+| Uint64                 | updatePassword                 |
 
 ### DataStoreChangeMetaParam ([Structure])
 
-| Type                              | Name           |
-|-----------------------------------|----------------|
-| Uint64                            | dataId         |
-| Uint32                            | modifiesFlag   |
-| [String]                          | name           |
-| [DataStorePermission]             | permission     |
-| [DataStorePermission]             | delPermission  |
-| Uint16                            | period         |
-| [qBuffer]                         | metaBinary     |
-| [List]&lt;[String]&gt;            | tags           |
-| Uint64                            | updatePassword |
-| Uint32                            | referredCnt    |
-| Uint16                            | dataType       |
-| Uint8                             | status         |
-| [DataStoreChangeMetaCompareParam] | compareParam   |
+| Type                              | Name                           |
+|-----------------------------------|--------------------------------|
+| Uint64                            | dataId                         |
+| Uint32                            | [modifiesFlag](#modifies-flag) |
+| [String]                          | name                           |
+| [DataStorePermission]             | permission                     |
+| [DataStorePermission]             | delPermission                  |
+| Uint16                            | period                         |
+| [qBuffer]                         | metaBinary                     |
+| [List]&lt;[String]&gt;            | tags                           |
+| Uint64                            | updatePassword                 |
+| Uint32                            | referredCnt                    |
+| Uint16                            | dataType                       |
+| Uint8                             | status                         |
+| [DataStoreChangeMetaCompareParam] | compareParam                   |
 
 Revision 1:
 
@@ -852,12 +852,12 @@ Revision 1:
 
 ### DataStoreGetMetaParam ([Structure])
 
-| Type                         | Name                           |
-|------------------------------|--------------------------------|
-| Uint64                       | dataId                         |
-| [DataStorePersistenceTarget] | persistenceTarget              |
+| Type                         | Name                            |
+|------------------------------|---------------------------------|
+| Uint64                       | dataId                          |
+| [DataStorePersistenceTarget] | persistenceTarget               |
 | Uint8                        | [resultOption](#result-options) |
-| Uint64                       | accessPassword                 |
+| Uint64                       | accessPassword                  |
 
 ### DataStoreRatingInfo ([Structure])
 
@@ -960,24 +960,24 @@ In NEX version 3.0, the data ID was set to a Uint64 and the version was set to a
 
 ### DataStoreSearchParam ([Structure])
 
-| Type                   | Name                           |
-|------------------------|--------------------------------|
-| Uint8                  | searchTarget                   |
-| [List]&lt;[PID]&gt;    | ownerIds                       |
-| Uint8                  | ownerType                      |
-| [List]&lt;Uint64&gt;   | destinationIds                 |
-| Uint16                 | dataType                       |
-| [DateTime]             | createdAfter                   |
-| [DateTime]             | createdBefore                  |
-| [DateTime]             | updatedAfter                   |
-| [DateTime]             | updatedBefore                  |
-| Uint32                 | referDataId                    |
-| [List]&lt;[String]&gt; | tags                           |
-| Uint8                  | resultOrderColumn              |
-| Uint8                  | resultOrder                    |
-| [ResultRange]          | resultRange                    |
+| Type                   | Name                            |
+|------------------------|---------------------------------|
+| Uint8                  | searchTarget                    |
+| [List]&lt;[PID]&gt;    | ownerIds                        |
+| Uint8                  | ownerType                       |
+| [List]&lt;Uint64&gt;   | destinationIds                  |
+| Uint16                 | dataType                        |
+| [DateTime]             | createdAfter                    |
+| [DateTime]             | createdBefore                   |
+| [DateTime]             | updatedAfter                    |
+| [DateTime]             | updatedBefore                   |
+| Uint32                 | referDataId                     |
+| [List]&lt;[String]&gt; | tags                            |
+| Uint8                  | resultOrderColumn               |
+| Uint8                  | resultOrder                     |
+| [ResultRange]          | resultRange                     |
 | Uint8                  | [resultOption](#result-options) |
-| Uint32                 | minimalRatingFrequency         |
+| Uint32                 | minimalRatingFrequency          |
 
 Revision 1:
 
@@ -993,27 +993,27 @@ Revision 2:
 
 In revision 3, a total count enabled field was added. Note that this field was inserted before the data types field:
 
-| Type                   | Name                           |
-|------------------------|--------------------------------|
-| Uint8                  | searchTarget                   |
-| [List]&lt;[PID]&gt;    | ownerIds                       |
-| Uint8                  | ownerType                      |
-| [List]&lt;Uint64&gt;   | destinationIds                 |
-| Uint16                 | dataType                       |
-| [DateTime]             | createdAfter                   |
-| [DateTime]             | createdBefore                  |
-| [DateTime]             | updatedAfter                   |
-| [DateTime]             | updatedBefore                  |
-| Uint32                 | referDataId                    |
-| [List]&lt;[String]&gt; | tags                           |
-| Uint8                  | resultOrderColumn              |
-| Uint8                  | resultOrder                    |
-| [ResultRange]          | resultRange                    |
+| Type                   | Name                            |
+|------------------------|---------------------------------|
+| Uint8                  | searchTarget                    |
+| [List]&lt;[PID]&gt;    | ownerIds                        |
+| Uint8                  | ownerType                       |
+| [List]&lt;Uint64&gt;   | destinationIds                  |
+| Uint16                 | dataType                        |
+| [DateTime]             | createdAfter                    |
+| [DateTime]             | createdBefore                   |
+| [DateTime]             | updatedAfter                    |
+| [DateTime]             | updatedBefore                   |
+| Uint32                 | referDataId                     |
+| [List]&lt;[String]&gt; | tags                            |
+| Uint8                  | resultOrderColumn               |
+| Uint8                  | resultOrder                     |
+| [ResultRange]          | resultRange                     |
 | Uint8                  | [resultOption](#result-options) |
-| Uint32                 | minimalRatingFrequency         |
-| Bool                   | useCache                       |
-| Bool                   | totalCountEnabled              |
-| [List]&lt;Uint16&gt;   | dataTypes                      |
+| Uint32                 | minimalRatingFrequency          |
+| Bool                   | useCache                        |
+| Bool                   | totalCountEnabled               |
+| [List]&lt;Uint16&gt;   | dataTypes                       |
 
 In NEX version 4.0, the revision number was set back to 0 with no other changes.
 
@@ -1221,7 +1221,6 @@ Permission types:
 | Sint16 | periodDuration |
 
 ### Result options
-
 In DataStore `resultOption` is a set of flags which determine what extra data gets returned when requesting an objects metadata. The following flags are used
 
 | Flag  | Description                             |
@@ -1229,6 +1228,22 @@ In DataStore `resultOption` is a set of flags which determine what extra data ge
 | `0x1` | Populate the objects `tags` field       |
 | `0x2` | Populate the objects `ratings` field    |
 | `0x4` | Populate the objects `metaBinary` field |
+
+### Modifies flag
+In DataStore `modifiesFlag` is a set of flags which determine what data gets updated when changing an objects metadata. The following flags are used. None of these changes update the objects `updatedTime` field besides flag `0x40`, which updates the S3 object itself. `updatedTime` likely refers to only the object, then, and not the metadata.
+
+| Flag    | Description                                                                                                     |
+|---------|-----------------------------------------------------------------------------------------------------------------|
+| `0x001` | Update objects `name` field                                                                                     |
+| `0x002` | Update objects access permission field                                                                          |
+| `0x004` | Update objects delete permission field                                                                          |
+| `0x008` | Update objects `period` field                                                                                   |
+| `0x010` | Update objects `metaBinary` field                                                                               |
+| `0x020` | Update objects `tags` field. Replaced, not appended                                                             |
+| `0x040` | Refresh objects expire time using the `period` field. If also using flag `0x8`, this uses the NEW `period`      |
+| `0x080` | Update objects `name` field                                                                                     |
+| `0x100` | Update objects `referredCnt` field. Set, not added                                                              |
+| `0x200` | Update objects `status` field. Anything besides `0` seems to result in `DataStore::NotFound` on future requests |
 
 [Result]: /docs/nex/types#result
 [String]: /docs/nex/types#string

--- a/docs/nex/protocols/datastore/index.md
+++ b/docs/nex/protocols/datastore/index.md
@@ -734,19 +734,19 @@ In NEX version 3.5, one more field was added:
 
 ### DataStorePreparePostParamV1 ([Structure])
 
-| Type                                             | Name             |
-|--------------------------------------------------|------------------|
-| Uint32                                           | size             |
-| [String]                                         | name             |
-| Uint16                                           | dataType         |
-| [qBuffer]                                        | metaBinary       |
-| [DataStorePermission]                            | permission       |
-| [DataStorePermission]                            | delPermission    |
-| Uint32                                           | flag             |
-| Uint16                                           | [period](#period)           |
-| Uint32                                           | referDataId      |
-| [List]&lt;[String]&gt;                           | tags             |
-| [List]&lt;[DataStoreRatingInitParamWithSlot]&gt; | ratingInitParams |
+| Type                                             | Name              |
+|--------------------------------------------------|-------------------|
+| Uint32                                           | size              |
+| [String]                                         | name              |
+| Uint16                                           | dataType          |
+| [qBuffer]                                        | metaBinary        |
+| [DataStorePermission]                            | permission        |
+| [DataStorePermission]                            | delPermission     |
+| Uint32                                           | flag              |
+| Uint16                                           | [period](#period) |
+| Uint32                                           | referDataId       |
+| [List]&lt;[String]&gt;                           | tags              |
+| [List]&lt;[DataStoreRatingInitParamWithSlot]&gt; | ratingInitParams  |
 
 ### DataStorePreparePostParam ([Structure])
 
@@ -821,7 +821,7 @@ In NEX version 3.5, one more field was added:
 | [String]               | name                           |
 | [DataStorePermission]  | permission                     |
 | [DataStorePermission]  | delPermission                  |
-| Uint16                 | [period](#period)                         |
+| Uint16                 | [period](#period)              |
 | [qBuffer]              | metaBinary                     |
 | [List]&lt;[String]&gt; | tags                           |
 | Uint64                 | updatePassword                 |
@@ -835,7 +835,7 @@ In NEX version 3.5, one more field was added:
 | [String]                          | name                           |
 | [DataStorePermission]             | permission                     |
 | [DataStorePermission]             | delPermission                  |
-| Uint16                            | [period](#period)                         |
+| Uint16                            | [period](#period)              |
 | [qBuffer]                         | metaBinary                     |
 | [List]&lt;[String]&gt;            | tags                           |
 | Uint64                            | updatePassword                 |
@@ -876,27 +876,27 @@ Revision 1:
 
 ### DataStoreMetaInfo ([Structure])
 
-| Type                                        | Name          |
-|---------------------------------------------|---------------|
-| Uint64                                      | dataId        |
-| [PID]                                       | ownerId       |
-| Uint32                                      | size          |
-| [String]                                    | name          |
-| Uint16                                      | dataType      |
-| [qBuffer]                                   | metaBinary    |
-| [DataStorePermission]                       | permission    |
-| [DataStorePermission]                       | delPermission |
-| [DateTime]                                  | createdTime   |
-| [DateTime]                                  | updatedTime   |
-| Uint16                                      | [period](#period)        |
-| Uint8                                       | status        |
-| Uint32                                      | referredCnt   |
-| Uint32                                      | referDataId   |
-| Uint32                                      | flag          |
-| [DateTime]                                  | referredTime  |
-| [DateTime]                                  | expireTime    |
-| [List]&lt;[String]&gt;                      | tags          |
-| [List]&lt;[DataStoreRatingInfoWithSlot]&gt; | ratings       |
+| Type                                        | Name              |
+|---------------------------------------------|-------------------|
+| Uint64                                      | dataId            |
+| [PID]                                       | ownerId           |
+| Uint32                                      | size              |
+| [String]                                    | name              |
+| Uint16                                      | dataType          |
+| [qBuffer]                                   | metaBinary        |
+| [DataStorePermission]                       | permission        |
+| [DataStorePermission]                       | delPermission     |
+| [DateTime]                                  | createdTime       |
+| [DateTime]                                  | updatedTime       |
+| Uint16                                      | [period](#period) |
+| Uint8                                       | status            |
+| Uint32                                      | referredCnt       |
+| Uint32                                      | referDataId       |
+| Uint32                                      | flag              |
+| [DateTime]                                  | referredTime      |
+| [DateTime]                                  | expireTime        |
+| [List]&lt;[String]&gt;                      | tags              |
+| [List]&lt;[DataStoreRatingInfoWithSlot]&gt; | ratings           |
 
 ### DataStorePrepareUpdateParam ([Structure])
 Up to NEX version 2.x, this structure looks as follows:
@@ -1194,18 +1194,18 @@ Permission types:
 
 ### DataStoreChangeMetaCompareParam ([Structure])
 
-| Type                   | Name           |
-|------------------------|----------------|
-| Uint32                 | comparisonFlag |
-| [String]               | name           |
-| [DataStorePermission]  | permission     |
-| [DataStorePermission]  | delPermission  |
-| Uint16                 | [period](#period)         |
-| [qBuffer]              | metaBinary     |
-| [List]&lt;[String]&gt; | tags           |
-| Uint32                 | referredCnt    |
-| Uint16                 | dataType       |
-| Uint8                  | status         |
+| Type                   | Name              |
+|------------------------|-------------------|
+| Uint32                 | comparisonFlag    |
+| [String]               | name              |
+| [DataStorePermission]  | permission        |
+| [DataStorePermission]  | delPermission     |
+| Uint16                 | [period](#period) |
+| [qBuffer]              | metaBinary        |
+| [List]&lt;[String]&gt; | tags              |
+| Uint32                 | referredCnt       |
+| Uint16                 | dataType          |
+| Uint8                  | status            |
 
 ### DataStoreRatingInitParam ([Structure])
 


### PR DESCRIPTION
Documents the various values for `modifiesFlag` used when updating an objects metadata. Also includes docs on what the `period` field is, as it relates to one of the flags