### PR TITLE
Updates with DDL param type 3 and OLS Storage

### DIFF
--- a/docs/ddl.md
+++ b/docs/ddl.md
@@ -170,12 +170,12 @@ The second parse tree item is always the same as the first parse tree item. I do
 
 ## Parameter
 
-| Type             | Description              |
-|------------------|--------------------------|
-| [Variable]       | Variable                 |
-| [DeclarationUse] | Declaration use          |
-| Uint32           | Array size               |
-| Uint8            | Type (1=input, 2=output) |
+| Type             | Description                      |
+|------------------|----------------------------------|
+| [Variable]       | Variable                         |
+| [DeclarationUse] | Declaration use                  |
+| Uint32           | Array size                       |
+| Uint8            | Type (1=input, 2=output, 3=both) |
 
 ## ReturnValue
 

--- a/docs/nex/protocols/index.md
+++ b/docs/nex/protocols/index.md
@@ -49,10 +49,11 @@ See also: [RMC Protocol](/docs/rmc)
 
 ## Game-Specific
 
-| ID  | Game                       | Protocol                                     |
-|-----|----------------------------|----------------------------------------------|
-| 200 | Pokemon Bank               | [Shop](/docs/nex/protocols/shop)             |
-| 201 | Super Smash Bros. Ultimate | [Tournament](/docs/nex/protocols/tournament) |
+| ID  | Game                       | Protocol                                       |
+|-----|----------------------------|------------------------------------------------|
+| 200 | Pokemon Bank               | [Shop](/docs/nex/protocols/shop)               |
+| 200 | Rayman Legends             | [OLS storage](/docs/nex/protocols/ols-storage) |
+| 201 | Super Smash Bros. Ultimate | [Tournament](/docs/nex/protocols/tournament)   |
 
 ## Not provided by NEX
 Ubisoft games always use the original Quazal Rendez-Vous library instead of NEX. The following protocols are not implemented by NEX, but may seen in Ubisoft games:
@@ -87,7 +88,6 @@ Ubisoft games always use the original Quazal Rendez-Vous library instead of NEX.
 | ?  | [Web notifications storage](/docs/nex/protocols/web-notifications-storage)   |
 | ?  | [Title storage admin](/docs/nex/protocols/title-storage-admin)               |
 | ?  | [User storage admin](/docs/nex/protocols/user-storage-admin)                 |
-| ?  | [OLS storage](/docs/nex/protocols/ols-storage)                               |
 
 ## Internal protocols
 These protocols seem to be used internally by the servers. Likely for their inter-server communications. Many of these can only be observed through the [Debug](/docs/nex/protocols/debug) protocol. However some games implement subsets of these protocols

--- a/docs/nex/protocols/ols-storage.md
+++ b/docs/nex/protocols/ols-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 toc: true
-title: OLS Storage
+title: OLS Storage (200)
 ---
 
 ## Methods
@@ -19,11 +19,12 @@ title: OLS Storage
 | 9         | [QueryLeaderboard](#9-queryleaderboard)                  |
 | 10        | [QuerySmartSelection](#10-querysmartselection)           |
 | 11        | [SaveScore](#11-savescore)                               |
-| 12        | [SaveGhost](#12-saveghost)                               |
-| 13        | [QueryCompetitionsInfos](#13-querycompetitionsinfos)     |
-| 14        | [QueryCompetitionsHistory](#14-querycompetitionshistory) |
-| 15        | [QueryCompetitionOfTheDay](#15-querycompetitionoftheday) |
-| 16        | [QueryCompetition](#16-querycompetition)                 |
+| 12        | [SaveScoreInvasion](#12-savescoreinvasion)               |
+| 13        | [SaveGhost](#13-saveghost)                               |
+| 14        | [QueryCompetitionsInfos](#14-querycompetitionsinfos)     |
+| 15        | [QueryCompetitionsHistory](#15-querycompetitionshistory) |
+| 16        | [QueryCompetitionOfTheDay](#16-querycompetitionoftheday) |
+| 17        | [SaveLevelProgression](#17-savelevelprogression)         |
 
 ### (1) LoadVersion
 
@@ -32,10 +33,11 @@ This method does not take any parameters
 
 #### Response
 
-| Type     | Name        |
-| -------- | ----------- |
-| Sint32   | version     |
-| [String] | sandboxName |
+| Type     | Name            |
+| -------- | --------------- |
+| Sint32   | version         |
+| [String] | sandboxName     |
+| Uint32   | applicationMask |
 
 ### (2) SaveLocale
 
@@ -44,6 +46,7 @@ This method does not take any parameters
 | Type     | Name       |
 | -------- | ---------- |
 | [String] | localeCode |
+| [String] | playerName |
 
 #### Response
 This method does not return anything
@@ -52,22 +55,20 @@ This method does not return anything
 
 #### Request
 
-| Type   | Name              |
-| ------ | ----------------- |
-| Uint32 | update_bitfield   |
-| Sint8  | level             |
-| Sint32 | currency          |
-| Uint32 | costume           |
-| Uint16 | bronze_medals     |
-| Uint16 | silver_medals     |
-| Uint16 | gold_medals       |
-| Uint16 | diamond_medals    |
-| Uint32 | run_distance      |
-| Uint16 | teensies_freed    |
-| Uint32 | jumps             |
-| Uint16 | unlocked_pets     |
-| Uint64 | pets              |
-| Uint16 | unlocked_costumes |
+| Type   | Name            |
+| ------ | --------------- |
+| Uint32 | update_bitfield |
+| Sint8  | level           |
+| Sint32 | currency        |
+| Uint32 | costume         |
+| Uint16 | bronze_medals   |
+| Uint16 | silver_medals   |
+| Uint16 | gold_medals     |
+| Uint16 | diamond_medals  |
+| Uint32 | run_distance    |
+| Uint16 | kills           |
+| Uint32 | jumps           |
+| Uint16 | deaths          |
 
 #### Response
 
@@ -77,6 +78,7 @@ This method does not return anything
 | Uint16 | competition_medals_1 |
 | Uint16 | competition_medals_2 |
 | Uint16 | competition_medals_3 |
+| Bool   | demoProfile          |
 
 ### (4) LoadIDCard
 
@@ -157,7 +159,6 @@ This method does not take any parameters
 | [List]&#x3C;Float&#x3E;                             | graduations  |
 | [List]&#x3C;Uint32&#x3E;                            | envelope     |
 | Uint32                                              | unit         |
-| Uint32                                              | my_country   |
 | Uint32                                              | participants |
 | Bool                                                | cacheable    |
 
@@ -171,10 +172,11 @@ This method does not take any parameters
 
 #### Response
 
-| Type                                                            | Name   |
-| --------------------------------------------------------------- | ------ |
-| [List]&#x3C;[OLSSelectionRow](#olsselectionrow-structure)&#x3E; | ghosts |
-| [List]&#x3C;[OLSTomb](#olstomb-structure)&#x3E;                 | tombs  |
+| Type                                                            | Name            |
+| --------------------------------------------------------------- | --------------- |
+| [List]&#x3C;[OLSSelectionRow](#olsselectionrow-structure)&#x3E; | ghosts          |
+| [List]&#x3C;[OLSTomb](#olstomb-structure)&#x3E;                 | tombs           |
+| Uint32                                                          | numParticipants |
 
 ### (11) SaveScore
 
@@ -200,7 +202,19 @@ This method does not take any parameters
 | [String] | message_medal   |
 | [String] | message_friends |
 
-### (12) SaveGhost
+### (12) SaveScoreInvasion
+
+#### Request
+
+| Type   | Name           |
+| ------ | -------------- |
+| Uint32 | id_leaderboard |
+| Float  | score          |
+
+#### Response
+This method does not return anything
+
+### (13) SaveGhost
 
 #### Request
 
@@ -214,7 +228,7 @@ This method does not take any parameters
 #### Response
 This method does not return anything
 
-### (13) QueryCompetitionsInfos
+### (14) QueryCompetitionsInfos
 
 #### Request
 This method does not take any parameters
@@ -225,7 +239,7 @@ This method does not take any parameters
 | ----------------------------------------------------------------------- | ----- |
 | [List]&#x3C;[OLSCompetitionInfos](#olscompetitioninfos-structure)&#x3E; | infos |
 
-### (14) QueryCompetitionsHistory
+### (15) QueryCompetitionsHistory
 
 #### Request
 
@@ -242,7 +256,7 @@ This method does not take any parameters
 | [List]&#x3C;[OLSCompetitionResult](#olscompetitionresult-structure)&#x3E; | history |
 | Uint32                                                                    | total   |
 
-### (15) QueryCompetitionOfTheDay
+### (16) QueryCompetitionOfTheDay
 
 #### Request
 
@@ -252,25 +266,22 @@ This method does not take any parameters
 
 #### Response
 
-| Type                                        | Name            |
-| ------------------------------------------- | --------------- |
-| [OLSCompetition](#olscompetition-structure) | competition     |
-| Uint32                                      | remaningSeconds |
-| [OLSCompetition](#olscompetition-structure) | tomorrow        |
+| Type                                                | Name            |
+| --------------------------------------------------- | --------------- |
+| [OLSCompetition](#olscompetition-structure)         | competition     |
+| Uint32                                              | remaningSeconds |
+| [List]&#x3C;[OLSLdbRow](#olsldbrow-structure)&#x3E; | friendsRanking  |
 
-### (16) QueryCompetition
+### (17) SaveLevelProgression
 
 #### Request
 
-| Type   | Name           |
-| ------ | -------------- |
-| Uint32 | id_competition |
+| Type                                              | Name   |
+| ------------------------------------------------- | ------ |
+| [List]&#x3C;[OLSLevel](#olslevel-structure)&#x3E; | levels |
 
 #### Response
-
-| Type                                        | Name        |
-| ------------------------------------------- | ----------- |
-| [OLSCompetition](#olscompetition-structure) | competition |
+This method does not return anything
 
 ## Types
 
@@ -279,7 +290,6 @@ This method does not take any parameters
 | Type     | Name       |
 | -------- | ---------- |
 | Sint32   | PID        |
-| [String] | PlatformID |
 | [String] | Name       |
 | Uint32   | costume    |
 | Uint32   | country    |
@@ -287,11 +297,10 @@ This method does not take any parameters
 
 ### OLSRichProfile ([Structure])
 
-| Type | Name |
-| --- | --- |
+| Type     | Name                 |
+| -------- | -------------------- |
 | Sint32   | PID                  |
 | [String] | Name                 |
-| [String] | PlatformID           |
 | Sint16   | Country              |
 | Uint32   | StatusIcon           |
 | Uint32   | lastCostume          |
@@ -310,14 +319,12 @@ This method does not take any parameters
 | Uint32   | rank_distanceRun     |
 | Float    | lums                 |
 | Uint32   | rank_lums            |
-| Float    | pets                 |
-| Uint32   | rank_pets            |
-| Float    | teensies             |
-| Uint32   | rank_teensies        |
+| Float    | deaths               |
+| Uint32   | rank_deaths          |
 | Float    | jumps                |
 | Uint32   | rank_jumps           |
-| Float    | costumes             |
-| Uint32   | rank_costumes        |
+| Float    | kills                |
+| Uint32   | rank_kills           |
 | Float    | stat_daily           |
 | Uint32   | rank_daily           |
 | Sint8    | unit_daily           |
@@ -368,15 +375,20 @@ This method does not take any parameters
 
 ### OLSCompetition ([Structure])
 
-| Type                                                    | Name             |
-| ------------------------------------------------------- | ---------------- |
-| [OLSCompetitionResult](#olscompetitionresult-structure) | result           |
-| [String]                                                | message          |
-| Uint32                                                  | seed             |
-| Float                                                   | objective        |
-| Float                                                   | score_validation |
-| Uint32                                                  | id_bricks        |
-| Float                                                   | score            |
+| Type                                                    | Name              |
+| ------------------------------------------------------- | ----------------- |
+| [OLSCompetitionResult](#olscompetitionresult-structure) | result            |
+| [String]                                                | message           |
+| Uint32                                                  | seed              |
+| Float                                                   | objective         |
+| Float                                                   | score_validation  |
+| Uint64                                                  | id_bricks         |
+| Float                                                   | score             |
+| Float                                                   | medalThresholds_0 |
+| Float                                                   | medalThresholds_1 |
+| Float                                                   | medalThresholds_2 |
+| Float                                                   | medalThresholds_3 |
+
 
 ### OLSSelectionRow ([Structure])
 
@@ -388,6 +400,7 @@ This method does not take any parameters
 | Uint32   | id_costume |
 | Uint32   | country    |
 | Uint32   | level      |
+| Uint32   | rank       |
 | Float    | score      |
 
 ### OLSCompetitionInfos ([Structure])
@@ -411,6 +424,7 @@ This method does not take any parameters
 | Uint32   | ID         |
 | [String] | name       |
 | Float    | value      |
+| Uint32   | rank       |
 | Uint32   | costume    |
 | Uint32   | statusIcon |
 | Uint32   | country    |
@@ -432,6 +446,15 @@ This method does not take any parameters
 | ------ | ------------ |
 | Sint32 | pid          |
 | Uint32 | relationship |
+
+### OLSLevel ([Structure])
+
+| Type     | Name          |
+| -------- | ------------- |
+| Uint32   | level_id      |
+| Uint32   | lums_count    |
+| Uint32   | teensies_mask |
+| Float    | best_time     |
 
 [Result]: /docs/nex/types#result
 [String]: /docs/nex/types#string

--- a/docs/nex/protocols/ols-storage/challenges-app.md
+++ b/docs/nex/protocols/ols-storage/challenges-app.md
@@ -1,8 +1,10 @@
 ---
 layout: post
 toc: true
-title: OLS Storage (200)
+title: Rayman Legends Challenges App (200)
 ---
+
+This page contains an early version of the [OLS Storage](/docs/nex/protocols/ols-storage) protocol used in Rayman Legends Challenges App.
 
 ## Methods
 
@@ -19,12 +21,11 @@ title: OLS Storage (200)
 | 9         | [QueryLeaderboard](#9-queryleaderboard)                  |
 | 10        | [QuerySmartSelection](#10-querysmartselection)           |
 | 11        | [SaveScore](#11-savescore)                               |
-| 12        | [SaveScoreInvasion](#12-savescoreinvasion)               |
-| 13        | [SaveGhost](#13-saveghost)                               |
-| 14        | [QueryCompetitionsInfos](#14-querycompetitionsinfos)     |
-| 15        | [QueryCompetitionsHistory](#15-querycompetitionshistory) |
-| 16        | [QueryCompetitionOfTheDay](#16-querycompetitionoftheday) |
-| 17        | [SaveLevelProgression](#17-savelevelprogression)         |
+| 12        | [SaveGhost](#12-saveghost)                               |
+| 13        | [QueryCompetitionsInfos](#13-querycompetitionsinfos)     |
+| 14        | [QueryCompetitionsHistory](#14-querycompetitionshistory) |
+| 15        | [QueryCompetitionOfTheDay](#15-querycompetitionoftheday) |
+| 16        | [QueryCompetition](#16-querycompetition)                 |
 
 ### (1) LoadVersion
 
@@ -33,11 +34,10 @@ This method does not take any parameters
 
 #### Response
 
-| Type     | Name            |
-| -------- | --------------- |
-| Sint32   | version         |
-| [String] | sandboxName     |
-| Uint32   | applicationMask |
+| Type     | Name        |
+| -------- | ----------- |
+| Sint32   | version     |
+| [String] | sandboxName |
 
 ### (2) SaveLocale
 
@@ -46,7 +46,6 @@ This method does not take any parameters
 | Type     | Name       |
 | -------- | ---------- |
 | [String] | localeCode |
-| [String] | playerName |
 
 #### Response
 This method does not return anything
@@ -55,20 +54,22 @@ This method does not return anything
 
 #### Request
 
-| Type   | Name            |
-| ------ | --------------- |
-| Uint32 | update_bitfield |
-| Sint8  | level           |
-| Sint32 | currency        |
-| Uint32 | costume         |
-| Uint16 | bronze_medals   |
-| Uint16 | silver_medals   |
-| Uint16 | gold_medals     |
-| Uint16 | diamond_medals  |
-| Uint32 | run_distance    |
-| Uint16 | kills           |
-| Uint32 | jumps           |
-| Uint16 | deaths          |
+| Type   | Name              |
+| ------ | ----------------- |
+| Uint32 | update_bitfield   |
+| Sint8  | level             |
+| Sint32 | currency          |
+| Uint32 | costume           |
+| Uint16 | bronze_medals     |
+| Uint16 | silver_medals     |
+| Uint16 | gold_medals       |
+| Uint16 | diamond_medals    |
+| Uint32 | run_distance      |
+| Uint16 | teensies_freed    |
+| Uint32 | jumps             |
+| Uint16 | unlocked_pets     |
+| Uint64 | pets              |
+| Uint16 | unlocked_costumes |
 
 #### Response
 
@@ -78,7 +79,6 @@ This method does not return anything
 | Uint16 | competition_medals_1 |
 | Uint16 | competition_medals_2 |
 | Uint16 | competition_medals_3 |
-| Bool   | demoProfile          |
 
 ### (4) LoadIDCard
 
@@ -159,6 +159,7 @@ This method does not take any parameters
 | [List]&#x3C;Float&#x3E;                             | graduations  |
 | [List]&#x3C;Uint32&#x3E;                            | envelope     |
 | Uint32                                              | unit         |
+| Uint32                                              | my_country   |
 | Uint32                                              | participants |
 | Bool                                                | cacheable    |
 
@@ -172,11 +173,10 @@ This method does not take any parameters
 
 #### Response
 
-| Type                                                            | Name            |
-| --------------------------------------------------------------- | --------------- |
-| [List]&#x3C;[OLSSelectionRow](#olsselectionrow-structure)&#x3E; | ghosts          |
-| [List]&#x3C;[OLSTomb](#olstomb-structure)&#x3E;                 | tombs           |
-| Uint32                                                          | numParticipants |
+| Type                                                            | Name   |
+| --------------------------------------------------------------- | ------ |
+| [List]&#x3C;[OLSSelectionRow](#olsselectionrow-structure)&#x3E; | ghosts |
+| [List]&#x3C;[OLSTomb](#olstomb-structure)&#x3E;                 | tombs  |
 
 ### (11) SaveScore
 
@@ -202,19 +202,7 @@ This method does not take any parameters
 | [String] | message_medal   |
 | [String] | message_friends |
 
-### (12) SaveScoreInvasion
-
-#### Request
-
-| Type   | Name           |
-| ------ | -------------- |
-| Uint32 | id_leaderboard |
-| Float  | score          |
-
-#### Response
-This method does not return anything
-
-### (13) SaveGhost
+### (12) SaveGhost
 
 #### Request
 
@@ -228,7 +216,7 @@ This method does not return anything
 #### Response
 This method does not return anything
 
-### (14) QueryCompetitionsInfos
+### (13) QueryCompetitionsInfos
 
 #### Request
 This method does not take any parameters
@@ -239,7 +227,7 @@ This method does not take any parameters
 | ----------------------------------------------------------------------- | ----- |
 | [List]&#x3C;[OLSCompetitionInfos](#olscompetitioninfos-structure)&#x3E; | infos |
 
-### (15) QueryCompetitionsHistory
+### (14) QueryCompetitionsHistory
 
 #### Request
 
@@ -256,7 +244,7 @@ This method does not take any parameters
 | [List]&#x3C;[OLSCompetitionResult](#olscompetitionresult-structure)&#x3E; | history |
 | Uint32                                                                    | total   |
 
-### (16) QueryCompetitionOfTheDay
+### (15) QueryCompetitionOfTheDay
 
 #### Request
 
@@ -266,22 +254,25 @@ This method does not take any parameters
 
 #### Response
 
-| Type                                                | Name            |
-| --------------------------------------------------- | --------------- |
-| [OLSCompetition](#olscompetition-structure)         | competition     |
-| Uint32                                              | remaningSeconds |
-| [List]&#x3C;[OLSLdbRow](#olsldbrow-structure)&#x3E; | friendsRanking  |
+| Type                                        | Name            |
+| ------------------------------------------- | --------------- |
+| [OLSCompetition](#olscompetition-structure) | competition     |
+| Uint32                                      | remaningSeconds |
+| [OLSCompetition](#olscompetition-structure) | tomorrow        |
 
-### (17) SaveLevelProgression
+### (16) QueryCompetition
 
 #### Request
 
-| Type                                              | Name   |
-| ------------------------------------------------- | ------ |
-| [List]&#x3C;[OLSLevel](#olslevel-structure)&#x3E; | levels |
+| Type   | Name           |
+| ------ | -------------- |
+| Uint32 | id_competition |
 
 #### Response
-This method does not return anything
+
+| Type                                        | Name        |
+| ------------------------------------------- | ----------- |
+| [OLSCompetition](#olscompetition-structure) | competition |
 
 ## Types
 
@@ -290,6 +281,7 @@ This method does not return anything
 | Type     | Name       |
 | -------- | ---------- |
 | Sint32   | PID        |
+| [String] | PlatformID |
 | [String] | Name       |
 | Uint32   | costume    |
 | Uint32   | country    |
@@ -297,10 +289,11 @@ This method does not return anything
 
 ### OLSRichProfile ([Structure])
 
-| Type     | Name                 |
-| -------- | -------------------- |
+| Type | Name |
+| --- | --- |
 | Sint32   | PID                  |
 | [String] | Name                 |
+| [String] | PlatformID           |
 | Sint16   | Country              |
 | Uint32   | StatusIcon           |
 | Uint32   | lastCostume          |
@@ -319,12 +312,14 @@ This method does not return anything
 | Uint32   | rank_distanceRun     |
 | Float    | lums                 |
 | Uint32   | rank_lums            |
-| Float    | deaths               |
-| Uint32   | rank_deaths          |
+| Float    | pets                 |
+| Uint32   | rank_pets            |
+| Float    | teensies             |
+| Uint32   | rank_teensies        |
 | Float    | jumps                |
 | Uint32   | rank_jumps           |
-| Float    | kills                |
-| Uint32   | rank_kills           |
+| Float    | costumes             |
+| Uint32   | rank_costumes        |
 | Float    | stat_daily           |
 | Uint32   | rank_daily           |
 | Sint8    | unit_daily           |
@@ -375,20 +370,15 @@ This method does not return anything
 
 ### OLSCompetition ([Structure])
 
-| Type                                                    | Name              |
-| ------------------------------------------------------- | ----------------- |
-| [OLSCompetitionResult](#olscompetitionresult-structure) | result            |
-| [String]                                                | message           |
-| Uint32                                                  | seed              |
-| Float                                                   | objective         |
-| Float                                                   | score_validation  |
-| Uint64                                                  | id_bricks         |
-| Float                                                   | score             |
-| Float                                                   | medalThresholds_0 |
-| Float                                                   | medalThresholds_1 |
-| Float                                                   | medalThresholds_2 |
-| Float                                                   | medalThresholds_3 |
-
+| Type                                                    | Name             |
+| ------------------------------------------------------- | ---------------- |
+| [OLSCompetitionResult](#olscompetitionresult-structure) | result           |
+| [String]                                                | message          |
+| Uint32                                                  | seed             |
+| Float                                                   | objective        |
+| Float                                                   | score_validation |
+| Uint32                                                  | id_bricks        |
+| Float                                                   | score            |
 
 ### OLSSelectionRow ([Structure])
 
@@ -400,7 +390,6 @@ This method does not return anything
 | Uint32   | id_costume |
 | Uint32   | country    |
 | Uint32   | level      |
-| Uint32   | rank       |
 | Float    | score      |
 
 ### OLSCompetitionInfos ([Structure])
@@ -424,7 +413,6 @@ This method does not return anything
 | Uint32   | ID         |
 | [String] | name       |
 | Float    | value      |
-| Uint32   | rank       |
 | Uint32   | costume    |
 | Uint32   | statusIcon |
 | Uint32   | country    |
@@ -446,15 +434,6 @@ This method does not return anything
 | ------ | ------------ |
 | Sint32 | pid          |
 | Uint32 | relationship |
-
-### OLSLevel ([Structure])
-
-| Type     | Name          |
-| -------- | ------------- |
-| Uint32   | level_id      |
-| Uint32   | lums_count    |
-| Uint32   | teensies_mask |
-| Float    | best_time     |
 
 [Result]: /docs/nex/types#result
 [String]: /docs/nex/types#string

--- a/docs/nex/protocols/ols-storage/index.md
+++ b/docs/nex/protocols/ols-storage/index.md
@@ -1,0 +1,472 @@
+---
+layout: post
+toc: true
+title: OLS Storage (200)
+---
+
+This page contains the protocol used on the retail version of Rayman Legends. To see the early version of this protocol used by Rayman Legends Challenges App, go to [this page](/docs/nex/protocols/ols-storage/challenges-app) instead.
+
+## Methods
+
+| Method ID | Method Name                                              |
+| --------- | -------------------------------------------------------- |
+| 1         | [LoadVersion](#1-loadversion)                            |
+| 2         | [SaveLocale](#2-savelocale)                              |
+| 3         | [SaveProfile](#3-saveprofile)                            |
+| 4         | [LoadIDCard](#4-loadidcard)                              |
+| 5         | [QueryFriendProfiles](#5-queryfriendprofiles)            |
+| 6         | [QueryUbisoftProfiles](#6-queryubisoftprofiles)          |
+| 7         | [CreateMessage](#7-createmessage)                        |
+| 8         | [QueryMessage](#8-querymessage)                          |
+| 9         | [QueryLeaderboard](#9-queryleaderboard)                  |
+| 10        | [QuerySmartSelection](#10-querysmartselection)           |
+| 11        | [SaveScore](#11-savescore)                               |
+| 12        | [SaveScoreInvasion](#12-savescoreinvasion)               |
+| 13        | [SaveGhost](#13-saveghost)                               |
+| 14        | [QueryCompetitionsInfos](#14-querycompetitionsinfos)     |
+| 15        | [QueryCompetitionsHistory](#15-querycompetitionshistory) |
+| 16        | [QueryCompetitionOfTheDay](#16-querycompetitionoftheday) |
+| 17        | [SaveLevelProgression](#17-savelevelprogression)         |
+
+### (1) LoadVersion
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type     | Name            |
+| -------- | --------------- |
+| Sint32   | version         |
+| [String] | sandboxName     |
+| Uint32   | applicationMask |
+
+### (2) SaveLocale
+
+#### Request
+
+| Type     | Name       |
+| -------- | ---------- |
+| [String] | localeCode |
+| [String] | playerName |
+
+#### Response
+This method does not return anything
+
+### (3) SaveProfile
+
+#### Request
+
+| Type   | Name            |
+| ------ | --------------- |
+| Uint32 | update_bitfield |
+| Sint8  | level           |
+| Sint32 | currency        |
+| Uint32 | costume         |
+| Uint16 | bronze_medals   |
+| Uint16 | silver_medals   |
+| Uint16 | gold_medals     |
+| Uint16 | diamond_medals  |
+| Uint32 | run_distance    |
+| Uint16 | kills           |
+| Uint32 | jumps           |
+| Uint16 | deaths          |
+
+#### Response
+
+| Type   | Name                 |
+| ------ | -------------------- |
+| Uint16 | competition_medals_0 |
+| Uint16 | competition_medals_1 |
+| Uint16 | competition_medals_2 |
+| Uint16 | competition_medals_3 |
+| Bool   | demoProfile          |
+
+### (4) LoadIDCard
+
+#### Request
+
+| Type  | Name |
+| ----- | ---- |
+| [PID] | pid  |
+
+#### Response
+
+| Type                                        | Name    |
+| ------------------------------------------- | ------- |
+| [OLSRichProfile](#olsrichprofile-structure) | profile |
+
+### (5) QueryFriendProfiles
+
+#### Request
+
+| Type                                                | Name    |
+| --------------------------------------------------- | ------- |
+| [List]&#x3C;[OLSFriend](#olsfriend-structure)&#x3E; | friends |
+
+#### Response
+
+| Type                                                  | Name     |
+| ----------------------------------------------------- | -------- |
+| [List]&#x3C;[OLSProfile](#olsprofile-structure)&#x3E; | profiles |
+
+### (6) QueryUbisoftProfiles
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type                                                  | Name     |
+| ----------------------------------------------------- | -------- |
+| [List]&#x3C;[OLSProfile](#olsprofile-structure)&#x3E; | profiles |
+
+### (7) CreateMessage
+
+#### Request
+
+| Type                                                      | Name         |
+| --------------------------------------------------------- | ------------ |
+| Uint32                                                    | message_type |
+| [List]&#x3C;Sint32&#x3E;                                  | receivers    |
+| [List]&#x3C;[OLSAttribute](#olsattribute-structure)&#x3E; | attributes   |
+
+#### Response
+This method does not return anything
+
+### (8) QueryMessage
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type                                                  | Name     |
+| ----------------------------------------------------- | -------- |
+| [List]&#x3C;[OLSMessage](#olsmessage-structure)&#x3E; | messages |
+
+### (9) QueryLeaderboard
+
+#### Request
+
+| Type   | Name           |
+| ------ | -------------- |
+| Uint32 | id_leaderboard |
+
+#### Response
+
+| Type                                                | Name         |
+| --------------------------------------------------- | ------------ |
+| [List]&#x3C;[OLSLdbRow](#olsldbrow-structure)&#x3E; | result       |
+| [List]&#x3C;Float&#x3E;                             | graduations  |
+| [List]&#x3C;Uint32&#x3E;                            | envelope     |
+| Uint32                                              | unit         |
+| Uint32                                              | participants |
+| Bool                                                | cacheable    |
+
+### (10) QuerySmartSelection
+
+#### Request
+
+| Type   | Name           |
+| ------ | -------------- |
+| Uint32 | id_leaderboard |
+
+#### Response
+
+| Type                                                            | Name            |
+| --------------------------------------------------------------- | --------------- |
+| [List]&#x3C;[OLSSelectionRow](#olsselectionrow-structure)&#x3E; | ghosts          |
+| [List]&#x3C;[OLSTomb](#olstomb-structure)&#x3E;                 | tombs           |
+| Uint32                                                          | numParticipants |
+
+### (11) SaveScore
+
+#### Request
+
+| Type   | Name                 |
+| ------ | -------------------- |
+| Uint32 | id_leaderboard       |
+| Bool   | is_objective_reached |
+| Float  | score                |
+| Float  | tomb_x               |
+| Float  | tomb_y               |
+| Float  | tomb_z               |
+| Uint32 | id_costume           |
+
+#### Response
+
+| Type     | Name            |
+| -------- | --------------- |
+| Bool     | save_score      |
+| Bool     | retry           |
+| Uint32   | medal           |
+| [String] | message_medal   |
+| [String] | message_friends |
+
+### (12) SaveScoreInvasion
+
+#### Request
+
+| Type   | Name           |
+| ------ | -------------- |
+| Uint32 | id_leaderboard |
+| Float  | score          |
+
+#### Response
+This method does not return anything
+
+### (13) SaveGhost
+
+#### Request
+
+| Type   | Name           |
+| ------ | -------------- |
+| Uint64 | id_ghost       |
+| Uint32 | id_competition |
+| Uint32 | id_costume     |
+| Float  | score          |
+
+#### Response
+This method does not return anything
+
+### (14) QueryCompetitionsInfos
+
+#### Request
+This method does not take any parameters
+
+#### Response
+
+| Type                                                                    | Name  |
+| ----------------------------------------------------------------------- | ----- |
+| [List]&#x3C;[OLSCompetitionInfos](#olscompetitioninfos-structure)&#x3E; | infos |
+
+### (15) QueryCompetitionsHistory
+
+#### Request
+
+| Type   | Name                |
+| ------ | ------------------- |
+| Uint32 | begin               |
+| Uint32 | amount              |
+| Uint32 | id_competition_meta |
+
+#### Response
+
+| Type                                                                      | Name    |
+| ------------------------------------------------------------------------- | ------- |
+| [List]&#x3C;[OLSCompetitionResult](#olscompetitionresult-structure)&#x3E; | history |
+| Uint32                                                                    | total   |
+
+### (16) QueryCompetitionOfTheDay
+
+#### Request
+
+| Type   | Name                |
+| ------ | ------------------- |
+| Uint32 | id_competition_meta |
+
+#### Response
+
+| Type                                                | Name            |
+| --------------------------------------------------- | --------------- |
+| [OLSCompetition](#olscompetition-structure)         | competition     |
+| Uint32                                              | remaningSeconds |
+| [List]&#x3C;[OLSLdbRow](#olsldbrow-structure)&#x3E; | friendsRanking  |
+
+### (17) SaveLevelProgression
+
+#### Request
+
+| Type                                              | Name   |
+| ------------------------------------------------- | ------ |
+| [List]&#x3C;[OLSLevel](#olslevel-structure)&#x3E; | levels |
+
+#### Response
+This method does not return anything
+
+## Types
+
+### OLSProfile ([Structure])
+
+| Type     | Name       |
+| -------- | ---------- |
+| Sint32   | PID        |
+| [String] | Name       |
+| Uint32   | costume    |
+| Uint32   | country    |
+| Sint8    | level      |
+
+### OLSRichProfile ([Structure])
+
+| Type     | Name                 |
+| -------- | -------------------- |
+| Sint32   | PID                  |
+| [String] | Name                 |
+| Sint16   | Country              |
+| Uint32   | StatusIcon           |
+| Uint32   | lastCostume          |
+| Uint16   | totalChallengePlayed |
+| Bool     | dailyPlayed          |
+| Bool     | weeklyPlayed         |
+| Bool     | dailyExpertPlayed    |
+| Bool     | weeklyExpertPlayed   |
+| Uint16   | DiamondMedals        |
+| Uint16   | GoldMedals           |
+| Uint16   | SilverMedals         |
+| Uint16   | BronzeMedals         |
+| Uint32   | GlobalMedalsRank     |
+| Uint32   | GlobalMedalsMaxRank  |
+| Float    | distanceRun          |
+| Uint32   | rank_distanceRun     |
+| Float    | lums                 |
+| Uint32   | rank_lums            |
+| Float    | deaths               |
+| Uint32   | rank_deaths          |
+| Float    | jumps                |
+| Uint32   | rank_jumps           |
+| Float    | kills                |
+| Uint32   | rank_kills           |
+| Float    | stat_daily           |
+| Uint32   | rank_daily           |
+| Sint8    | unit_daily           |
+| Float    | stat_weekly          |
+| Uint32   | rank_weekly          |
+| Sint8    | unit_weekly          |
+| Float    | stat_daily_expert    |
+| Uint32   | rank_daily_expert    |
+| Sint8    | unit_daily_expert    |
+| Float    | stat_weekly_expert   |
+| Uint32   | rank_weekly_expert   |
+| Sint8    | unit_weekly_expert   |
+
+### OLSAttribute ([Structure])
+
+| Type   | Name            |
+| ------ | --------------- |
+| Sint8  | attribute_type  |
+| Uint32 | attribute_value |
+
+### OLSMessage ([Structure])
+
+| Type                                                      | Name               |
+| --------------------------------------------------------- | ------------------ |
+| Sint8                                                     | message_type       |
+| Bool                                                      | message_prompt     |
+| Bool                                                      | message_drc        |
+| Bool                                                      | message_bloomberg  |
+| [DateTime]                                                | message_date       |
+| Uint32                                                    | message_duration   |
+| [String]                                                  | message_title      |
+| [String]                                                  | message_body       |
+| [List]&#x3C;[String]&#x3E;                                | message_buttons    |
+| [List]&#x3C;[OLSAttribute](#olsattribute-structure)&#x3E; | message_attributes |
+
+### OLSCompetitionResult ([Structure])
+
+| Type       | Name           |
+| ---------- | -------------- |
+| Uint32     | id_leaderboard |
+| [String]   | name           |
+| [DateTime] | begin          |
+| [DateTime] | end            |
+| Uint32     | level          |
+| Uint32     | mode           |
+| Uint32     | rank           |
+| Uint32     | max_rank       |
+
+### OLSCompetition ([Structure])
+
+| Type                                                    | Name              |
+| ------------------------------------------------------- | ----------------- |
+| [OLSCompetitionResult](#olscompetitionresult-structure) | result            |
+| [String]                                                | message           |
+| Uint32                                                  | seed              |
+| Float                                                   | objective         |
+| Float                                                   | score_validation  |
+| Uint64                                                  | id_bricks         |
+| Float                                                   | score             |
+| Float                                                   | medalThresholds_0 |
+| Float                                                   | medalThresholds_1 |
+| Float                                                   | medalThresholds_2 |
+| Float                                                   | medalThresholds_3 |
+
+
+### OLSSelectionRow ([Structure])
+
+| Type     | Name       |
+| -------- | ---------- |
+| Uint32   | ID         |
+| [String] | name       |
+| Uint64   | id_ghost   |
+| Uint32   | id_costume |
+| Uint32   | country    |
+| Uint32   | level      |
+| Uint32   | rank       |
+| Float    | score      |
+
+### OLSCompetitionInfos ([Structure])
+
+| Type                                                            | Name              |
+| --------------------------------------------------------------- | ----------------- |
+| Uint32                                                          | id_competition    |
+| Uint32                                                          | participants      |
+| [List]&#x3C;Uint32&#x3E;                                        | friends           |
+| Uint32                                                          | level_id          |
+| Uint32                                                          | mode              |
+| Uint32                                                          | my_rank           |
+| Uint32                                                          | remaining_seconds |
+| [List]&#x3C;[OLSSelectionRow](#olsselectionrow-structure)&#x3E; | competitors       |
+| Uint32                                                          | unit              |
+
+### OLSLdbRow ([Structure])
+
+| Type     | Name       |
+| -------- | ---------- |
+| Uint32   | ID         |
+| [String] | name       |
+| Float    | value      |
+| Uint32   | rank       |
+| Uint32   | costume    |
+| Uint32   | statusIcon |
+| Uint32   | country    |
+
+### OLSTomb ([Structure])
+
+| Type     | Name       |
+| -------- | ---------- |
+| Sint32   | pid        |
+| [String] | name       |
+| Uint32   | id_costume |
+| Float    | x          |
+| Float    | y          |
+| Float    | z          |
+
+### OLSFriend ([Structure])
+
+| Type   | Name         |
+| ------ | ------------ |
+| Sint32 | pid          |
+| Uint32 | relationship |
+
+### OLSLevel ([Structure])
+
+| Type     | Name          |
+| -------- | ------------- |
+| Uint32   | level_id      |
+| Uint32   | lums_count    |
+| Uint32   | teensies_mask |
+| Float    | best_time     |
+
+[Result]: /docs/nex/types#result
+[String]: /docs/nex/types#string
+[Buffer]: /docs/nex/types#buffer
+[qBuffer]: /docs/nex/types#qbuffer
+[List]: /docs/nex/types#list
+[Map]: /docs/nex/types#map
+[DateTime]: /docs/nex/types#datetime
+[Structure]: /docs/nex/types#structure
+[Data]: /docs/nex/types#anydataholder
+[StationURL]: /docs/nex/types#stationurl
+[Variant]: /docs/nex/types#variant
+[PID]: /docs/nex/types#pid

--- a/docs/nex/protocols/tracking-3.md
+++ b/docs/nex/protocols/tracking-3.md
@@ -44,9 +44,10 @@ This method does not return anything.
 ### (3) SendUserInfo
 #### Request
 
-| Type   | Name      |
-| ------ | --------- |
-| Uint32 | deltaTime |
+| Type                  | Name      |
+|-----------------------|-----------|
+| [TrackingInformation] | userInfo  |
+| Uint32                | deltaTime |
 
 #### Response
 

--- a/docs/nex/protocols/ubi-account-management.md
+++ b/docs/nex/protocols/ubi-account-management.md
@@ -34,7 +34,10 @@ title: Ubi Account Management (29)
 
 ### (1) CreateAccount
 #### Request
-This method does not take any parameters.
+
+| Type         | Name       |
+|--------------|------------|
+| [UbiAccount] | ubiAccount |
 
 #### Response
 
@@ -45,7 +48,10 @@ This method does not take any parameters.
 
 ### (2) UpdateAccount
 #### Request
-This method does not take any parameters.
+
+| Type         | Name       |
+|--------------|------------|
+| [UbiAccount] | ubiAccount |
 
 #### Response
 

--- a/docs/nex/protocols/user-storage.md
+++ b/docs/nex/protocols/user-storage.md
@@ -78,6 +78,7 @@ This method does not return anything.
 | Type                            | Name       |
 | ------------------------------- | ---------- |
 | [List]&lt;[ContentProperty]&gt; | properties |
+| [UserContentKey]                | contentKey |
 
 #### Response
 
@@ -92,6 +93,7 @@ This method does not return anything.
 | ------------------------------- | ---------- |
 | [List]&lt;[ContentProperty]&gt; | properties |
 | [Buffer]                        | data       |
+| [UserContentKey]                | contentKey |
 
 #### Response
 
@@ -119,10 +121,11 @@ This method does not return anything.
 ### (7) UploadEnd
 #### Request
 
-| Type   | Name      |
-| ------ | --------- |
-| Uint64 | pendingID |
-| Bool   | result    |
+| Type             | Name       |
+| ---------------- | ---------- |
+| Uint64           | pendingID  |
+| Bool             | result     |
+| [UserContentKey] | contentKey |
 
 #### Response
 


### PR DESCRIPTION
Add missing parameters on requests from DDL trees parameter type 3.

Also update OLS Storage to use DDL trees from retail version of Rayman Legends, and not Challenges App. This matches with the PC version too.