### PR TITLE
Add qUUID docs

### DIFF
--- a/docs/nex/types.md
+++ b/docs/nex/types.md
@@ -7,28 +7,28 @@ title: NEX common types
 ## String
 
 | Type   | Description                        |
-| ------ | ---------------------------------- |
+|--------|------------------------------------|
 | Uint16 | Length (including null terminator) |
 | Chars  | Null terminated UTF-8 string       |
 
 ## Buffer
 
 | Type   | Description |
-| ------ | ----------- |
+|--------|-------------|
 | Uint32 | Length      |
 | Bytes  | Data        |
 
 ## qBuffer
 
 | Type   | Description |
-| ------ | ----------- |
+|--------|-------------|
 | Uint16 | Length      |
 | Bytes  | Data        |
 
 ## List
 
 | Type   | Description       |
-| ------ | ----------------- |
+|--------|-------------------|
 | Uint32 | Number of entries |
 |        | Entries           |
 
@@ -39,14 +39,14 @@ A map is a [list](#list) of (key, value) pairs.
 Every user is given a unique id called principal id.
 
 | Platform    | Type   |
-| ----------- | ------ |
+|-------------|--------|
 | 3DS / Wii U | Uint32 |
 | Switch      | Uint64 |
 
 ## Result
 
 | Type   | Description |
-| ------ | ----------- |
+|--------|-------------|
 | Uint32 | Result code |
 
 If the most significant bit is set an error occurred. Otherwise, the result indicates success. A list of error codes can be found in [nintendo/nex/errors.py](https://github.com/Kinnay/NintendoClients/blob/master/nintendo/nex/errors.py).
@@ -54,13 +54,13 @@ If the most significant bit is set an error occurred. Otherwise, the result indi
 ## DateTime
 
 | Type   | Description |
-| ------ | ----------- |
+|--------|-------------|
 | Uint64 | Value       |
 
 This is not a normal time stamp. Instead, it consists of a bunch of bit fields:
 
 | Bits    | Description |
-| ------- | ----------- |
+|---------|-------------|
 | 63 - 26 | Year        |
 | 25 - 22 | Month       |
 | 21 - 17 | Day         |
@@ -71,13 +71,13 @@ This is not a normal time stamp. Instead, it consists of a bunch of bit fields:
 ## StationURL
 
 | Type     | Description |
-| -------- | ----------- |
+|----------|-------------|
 | [String] | Station URL |
 
 A station url contains the address and port of a server or client, along with a few parameters. The order of the fields is arbitrary. Here's an example station url: `prudps:/stream=10;sid=1;CID=1;type=2;address=34.210.222.104;port=60101;PID=2`
 
 | Field             | Description               |
-| ----------------- | ------------------------- |
+|-------------------|---------------------------|
 | &lt;scheme&gt;    | udp, prudp or prudps      |
 | address           | Address                   |
 | port              | Port                      |
@@ -99,7 +99,7 @@ A station url contains the address and port of a server or client, along with a 
 The following fields were added on Nintendo Switch:
 
 | Field | Description                             |
-| ----- | --------------------------------------- |
+|-------|-----------------------------------------|
 | Uri   | Uri                                     |
 | R     | Use relay server (0 or 1)               |
 | Rsa   | Relay server address                    |
@@ -115,7 +115,7 @@ The following fields were added on Nintendo Switch:
 A variant consists of an uint8 indicating the type followed by its value.
 
 | Type id | Type       |
-| ------- | ---------- |
+|---------|------------|
 | 0       | None       |
 | 1       | Sint64     |
 | 2       | Double     |
@@ -130,7 +130,7 @@ When using the ["verbose" RMC variation](/docs/rmc) the structure version inform
 ### Structure header
 
 | Type   | Description    |
-| ------ | -------------- |
+|--------|----------------|
 | Uint8  | Version        |
 | Uint32 | Content length |
 |        | Content        |
@@ -155,7 +155,7 @@ This struct does not have any fields.
 This class can hold any object derived from a given base class (usually [nn::nex::Data](#data-structure)). Some meta data is sent along with it, so the other side can properly identify and decode the object.
 
 | Type     | Description                                     |
-| -------- | ----------------------------------------------- |
+|----------|-------------------------------------------------|
 | [String] | Type name                                       |
 | Uint32   | Length of data, including the next length field |
 | Uint32   | Length of data                                  |
@@ -165,7 +165,7 @@ This class can hold any object derived from a given base class (usually [nn::nex
 Nintendo does not use any special protocols.
 
 | Type                       | Name                  | Description                        |
-| -------------------------- | --------------------- | ---------------------------------- |
+|----------------------------|-----------------------|------------------------------------|
 | [StationURL](#station-url) | m_urlRegularProtocols | Server address (regular protocols) |
 | [List](#list)&lt;byte&gt;  | m_lstSpecialProtocols | Special protocols                  |
 | [StationURL](#station-url) | m_urlSpecialProtocols | Server address (special protocols) |
@@ -173,13 +173,13 @@ Nintendo does not use any special protocols.
 Revision 1:
 
 | Type                   | Name             | Description |
-| ---------------------- | ---------------- | ----------- |
+|------------------------|------------------|-------------|
 | [DateTime](#date-time) | m_currentUTCTime | Time        |
 
 Examples:
 
 | Game    | Secure server                                                                  |
-| ------- | ------------------------------------------------------------------------------ |
+|---------|--------------------------------------------------------------------------------|
 | Friends | `prudps:/stream=10;type=2;PID=2;port=60091;address=35.162.205.114;sid=1;CID=1` |
 | DKC:TF  | `prudps:/port=43221;CID=1;address=34.208.166.202;PID=2;stream=10;type=2;sid=1` |
 | MK8     | `prudps:/sid=1;port=59201;address=52.10.188.163;PID=2;stream=10;type=2;CID=1`  |
@@ -188,9 +188,48 @@ Examples:
 Some methods query a large set of objects. These methods normally take a ResultRange parameter that limits the number of objects that are returned.
 
 | Type   | Name       | Description |
-| ------ | ---------- | ----------- |
+|--------|------------|-------------|
 | Uint32 | m_uiOffset | Offset      |
 | Uint32 | m_uiSize   | Length      |
+
+## qUUID
+A `qUUID` is a set of 16 bytes making up a UUID. These are usually UUIDv4 variant 8, but this is not required. The data is split into 7 little endian fields, the first 4 being the first 4 sections of the UUID with the 5th section being made of the remaining 3 fields. To convert to a UUID string, swap the endianness of each field back to big endian
+
+| Type      | Description      |
+|-----------|------------------|
+| Bytes (4) | Section 1        |
+| Bytes (2) | Section 2        |
+| Bytes (2) | Section 3        |
+| Bytes (2) | Section 4        |
+| Bytes (2) | Section 5 part 1 |
+| Bytes (2) | Section 5 part 2 |
+| Bytes (2) | Section 5 part 3 |
+
+Example:
+
+```python
+uuid = bytes.fromhex("ae5e3e66297d8c4aa98420499ad98c3e")
+
+section1 = uuid[0:4][::-1].hex()
+section2 = uuid[4:6][::-1].hex()
+section3 = uuid[6:8][::-1].hex()
+section4 = uuid[8:10][::-1].hex()
+section5_1 = uuid[10:12][::-1].hex()
+section5_2 = uuid[12:14][::-1].hex()
+section5_3 = uuid[14:16][::-1].hex()
+
+expected = "663e5eae-7d29-4a8c-84a9-4920d99a3e8c"
+
+"""
+Prints:
+
+663e5eae-7d29-4a8c-84a9-4920d99a3e8c
+663e5eae-7d29-4a8c-84a9-4920d99a3e8c
+"""
+
+print(expected)
+print("%s-%s-%s-%s-%s%s%s" % (section1, section2, section3, section4, section5_1, section5_2, section5_3))
+```
 
 [String]: #string
 [Structure]: #structure


### PR DESCRIPTION
Adds docs for the `qUUID` type. So far this has only been seen in WATCH_DOGS on the Wii U, but since Ubisoft uses it for their Uplay profile IDs in that game it's likely that this exist in at least other Ubisoft games

This doesn't document the red-black tree usage also seen in WATCH_DOGS when using `qUUID` types, as I have no idea what that's all about. It seems like WATCH_DOGS creates a red-black tree for each `qUUID`, but it's not clear what purpose this has. The game only seems to do this when extracting the `qUUID` from an RMC message, as it does not do this when creating a `qUUID` from a string for example. It also seems to not do anything with the tree when encoding the type?