### PR TITLE
ranking: Expand Ranking Legacy documentation

### DIFF
--- a/docs/nex/protocols/ranking/legacy.md
+++ b/docs/nex/protocols/ranking/legacy.md
@@ -12,13 +12,13 @@ Scores are stored as a `List<Uint32>` for assigning multiple scores to a [Rankin
 
 In NEX 1, the category is represented as a `List<Uint16>`, but the server will only accept having a single value on the list.
 
-The common data is used on games to display user information on the ranking. Its value is game-specific on NEX 2, but on NEX 1 this must be an always-allocated 0x14-byte buffer which stores the player's name in UTF-16. If a user doesn't have common data or it has been deleted, any methods that query it will give an empty buffer, still allocated on NEX 1.
+The common data is used in games to display user information on the ranking. Its value is game-specific on NEX 2, but on NEX 1 this must be an always-allocated 0x14-byte buffer which stores the player's name in UTF-16. If a user doesn't have common data or it has been deleted, any methods that query it will give an empty buffer, still allocated on NEX 1.
 
 In some cases, when using a unique ID that doesn't exist on a method that requires it, the server will give error `0x00670004`.
 
 ## Extended Protocols
 
-The following games have additional methods in the ranking protocol:
+The following games have additional methods in the legacy ranking protocol:
 * [Mario Kart 7](/docs/nex/protocols/ranking/mario-kart-7)
 
 ## Methods
@@ -132,7 +132,7 @@ The following games have additional methods in the ranking protocol:
 
 ### (7) UnknownMethod0x7
 
-This method requires ownership of the unique ID, and having scores in the given category. In NEX 1, the server will return `Ranking::RegistrationError` if the user doesn't have scores in the given category.
+This method requires ownership of the unique ID, and having scores in the given category. In NEX 1, the server will return `Ranking::RegistrationError` if the user doesn't have scores in the given category. In NEX 2, `Ranking::NotFound` is returned instead.
 
 #### Request
 

--- a/docs/nex/protocols/ranking/legacy.md
+++ b/docs/nex/protocols/ranking/legacy.md
@@ -6,18 +6,102 @@ title: Ranking - Legacy (112)
 
 This protocol is the old version of the [Ranking](/docs/nex/protocols/ranking) protocol. It was rewritten on NEX 3.0.0.
 
+All methods include a `Sint16` on the response, possibly being used as a result code but this isn't certain. A method will always give the same value on this field, but this value may be different between methods.
+
+Scores are stored as a `List<Uint32>` for assigning multiple scores to a [RankingData]. All scores must contain 2 elements, even if the game doesn't use the second value.
+
+In NEX 1, the category is represented as a `List<Uint16>`, but the server will only accept having a single value on the list.
+
+The common data is used on games to display user information on the ranking. Its value is game-specific on NEX 2, but on NEX 1 this must be an always-allocated 0x14-byte buffer which stores the player's name in UTF-16. If a user doesn't have common data or it has been deleted, any methods that query it will give an empty buffer, still allocated on NEX 1.
+
+In some cases, when using a unique ID that doesn't exist on a method that requires it, the server will give error `0x00670004`.
+
+## Extended Protocols
+
+The following games have additional methods in the ranking protocol:
+* [Mario Kart 7](/docs/nex/protocols/ranking/mario-kart-7)
+
 ## Methods
 
-| Method ID | Method Name                                                |
-| --------- | ---------------------------------------------------------- |
-| 5         | [UploadCommonData](#5-uploadcommondata)                    |
-| 14        | [UnknownMethod0xE](#14-unknownmethod0xe)                   |
-| 15        | [UnknownMethod0xF](#15-unknownmethod0xf)                   |
-| 16        | [GetTotal](#16-gettotal)                                   |
-| 17        | [UploadScoreWithLimit](#17-uploadscorewithlimit)           |
-| 20        | [UploadSpecificPeriodScore](#20-uploadspecificperiodscore) |
-| 22        | [GetSpecificPeriodDataList](#22-getspecificperioddatalist) |
-| 25        | [GetSpecificPeriodTotal](#25-getspecificperiodtotal)       |
+| Method ID (NEX 1) | Method ID (NEX 2) | Method Name                                        |
+|-------------------|-------------------|----------------------------------------------------|
+| 1                 | 1                 | [UploadScore](#1-uploadscore)                      |
+|                   | 2                 | [UploadScores](#2-uploadscores)                    |
+| 2                 | 3                 | [DeleteScore](#3-deletescore)                      |
+| 3                 | 4                 | [DeleteAllScore](#4-deleteallscore)                |
+| 4                 | 5                 | [UploadCommonData](#5-uploadcommondata)            |
+| 5                 | 6                 | [DeleteCommonData](#6-deletecommondata)            |
+| 6                 | 7                 | [UnknownMethod0x7](#7-unknownmethod0x7)            |
+| 7                 | 8                 | [UnknownMethod0x8](#8-unknownmethod0x8)            |
+|                   | 9                 | [UnknownMethod0x9](#9-unknownmethod0x9)            |
+| 8                 | 10                | [GetTopScore](#10-gettopscore)                     |
+| 9                 | 11                | [GetCommonData](#11-getcommondata)                 |
+| 10                | 12                | [UnknownMethod0xC](#12-unknownmethod0xc)           |
+| 11                | 13                | [UnknownMethod0xD](#13-unknownmethod0xd)           |
+| 12                | 14                | [UnknownMethod0xE](#14-unknownmethod0xe)           |
+| 13                | 15                | [UnknownMethod0xF](#15-unknownmethod0xf)           |
+| 14                | 16                | [GetTotal](#16-gettotal)                           |
+|                   | 17                | [UploadScoreWithLimit](#17-uploadscorewithlimit)   |
+|                   | 18                | [UploadScoresWithLimit](#18-uploadscoreswithlimit) |
+|                   | 19                | [UnknownMethod0x13](#19-unknownmethod0x13)         |
+
+### (1) UploadScore
+#### Request
+
+| Type                                           | Description |
+|------------------------------------------------|-------------|
+| Uint32                                         | Unique ID   |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+| [List]&lt;Uint32&gt;                           | Scores      |
+| Uint8                                          | Unknown (1) |
+| Uint32                                         | Unknown (2) |
+
+#### Response
+
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (50) |
+
+### (2) UploadScores
+#### Request
+
+| Type                         | Description |
+|------------------------------|-------------|
+| Uint32                       | Unique ID   |
+| [List]&lt;[RankingScore]&gt; | Scores      |
+
+#### Response
+
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (50) |
+
+### (3) DeleteScore
+#### Request
+
+| Type                                           | Description |
+|------------------------------------------------|-------------|
+| Uint32                                         | Unique ID   |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+
+#### Response
+
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (50) |
+
+### (4) DeleteAllScore
+#### Request
+
+| Type   | Description |
+|--------|-------------|
+| Uint32 | Unique ID   |
+
+#### Response
+
+| Type   | Description       |
+|--------|-------------------|
+| Sint16 | Result code (100) |
 
 ### (5) UploadCommonData
 #### Request
@@ -29,76 +113,200 @@ This protocol is the old version of the [Ranking](/docs/nex/protocols/ranking) p
 
 #### Response
 
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (50) |
+
+### (6) DeleteCommonData
+#### Request
+
 | Type   | Description |
 |--------|-------------|
-| Uint16 | Unknown     |
+| Uint32 | Unique ID   |
+
+#### Response
+
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (50) |
+
+### (7) UnknownMethod0x7
+
+This method requires ownership of the unique ID, and having scores in the given category. In NEX 1, the server will return `Ranking::RegistrationError` if the user doesn't have scores in the given category.
+
+#### Request
+
+| Type                                           | Description |
+|------------------------------------------------|-------------|
+| Uint32                                         | Unique ID   |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+
+#### Response
+
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (50) |
+
+### (8) UnknownMethod0x8
+
+This method requires ownership of the unique ID.
+
+#### Request
+
+| Type   | Description |
+|--------|-------------|
+| Uint32 | Unique ID   |
+
+#### Response
+
+| Type   | Description       |
+|--------|-------------------|
+| Sint16 | Result code (100) |
+
+### (9) UnknownMethod0x9
+#### Request
+
+| Type                 | Description |
+|----------------------|-------------|
+| Uint32               | Unknown (1) |
+| Uint32               | Unknown (2) |
+| [List]&lt;Uint32&gt; | Unknown (3) |
+| [List]&lt;Uint8&gt;  | Unknown (4) |
+
+#### Response
+
+The response format of this method is unknown.
+
+### (10) GetTopScore
+#### Request
+
+| Type                                           | Description |
+|------------------------------------------------|-------------|
+| Uint32                                         | Unique ID   |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+
+#### Response
+
+| Type                 | Description      |
+|----------------------|------------------|
+| Sint16               | Result code (20) |
+| [List]&lt;Uint32&gt; | Scores           |
+
+### (11) GetCommonData
+#### Request
+
+| Type     | Description |
+|----------|-------------|
+| Uint32   | Unique ID   |
+
+#### Response
+
+| Type     | Description      |
+|----------|------------------|
+| Sint16   | Result code (20) |
+| [Buffer] | Common data      |
+
+### (12) UnknownMethod0xC
+#### Request
+
+| Type                                           | Description |
+|------------------------------------------------|-------------|
+| Uint32                                         | Unique ID   |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+
+#### Response
+
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (20) |
+| Uint8  | Unknown          |
+
+### (13) UnknownMethod0xD
+#### Request
+
+| Type                                           | Description |
+|------------------------------------------------|-------------|
+| Uint32                                         | Unique ID   |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+| Uint8                                          | Unknown (1) |
+| Uint8                                          | Unknown (2) |
+
+#### Response
+
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (20) |
+| Uint32 | Unknown          |
 
 ### (14) UnknownMethod0xE
 #### Request
 
-| Type   | Description             |
-|--------|-------------------------|
-| Uint8  | [Ranking mode]          |
-| Uint32 | Category                |
-| Uint8  | Score index to order by |
-| Uint8  | Unknown (1)             |
-| Uint8  | Unknown (2)             |
-| Uint8  | Unknown (3)             |
-| Uint8  | Unknown (4)             |
-| Uint8  | Unknown (5)             |
-| Uint32 | Unknown (6)             |
-| Uint32 | Offset                  |
-| Uint8  | Length                  |
+| Type                                           | Description                       |
+|------------------------------------------------|-----------------------------------|
+| Uint8                                          | [Ranking mode]                    |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category                          |
+| Uint8                                          | Score index to order by           |
+| Uint8                                          | 0: Lowest score, 1: Highest score |
+| Uint8                                          | [Rank calculation]                |
+| Uint8                                          | Unknown (1)                       |
+| Uint8                                          | Unknown (2)                       |
+| Uint8                                          | Unknown (3)                       |
+| Uint32                                         | Unknown (4)                       |
+| Uint32                                         | Offset                            |
+| Uint8                                          | Length                            |
 
 #### Response
 
-| Type                        | Description    |
-|-----------------------------|----------------|
-| Uint16                      | Unknown        |
-| [List]&lt;[RankingData]&gt; | Rank data list |
+| Type                        | Description      |
+|-----------------------------|------------------|
+| Sint16                      | Result code (30) |
+| [List]&lt;[RankingData]&gt; | Rank data list   |
 
 ### (15) UnknownMethod0xF
 #### Request
 
-| Type   | Description            |
-|--------|------------------------|
-| Uint32 | Unique ID              |
-| Uint32 | Category               |
-| Uint8  | Score index to sort by |
-| Uint8  | Unknown (1)            |
-| Uint8  | Unknown (2)            |
-| Uint8  | Unknown (3)            |
-| Uint8  | Unknown (4)            |
-| Uint8  | Unknown (5)            |
-| Uint32 | Unknown (6)            |
-| Uint8  | Length                 |
+| Type                                           | Description                       |
+|------------------------------------------------|-----------------------------------|
+| Uint32                                         | Unique ID                         |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category                          |
+| Uint8                                          | Score index to sort by            |
+| Uint8                                          | 0: Lowest score, 1: Highest score |
+| Uint8                                          | [Rank calculation]                |
+| Uint8                                          | Unknown (1)                       |
+| Uint8                                          | Unknown (2)                       |
+| Uint8                                          | Unknown (3)                       |
+| Uint32                                         | Unknown (4)                       |
+| Uint8                                          | Length                            |
 
 #### Response
 
-| Type                        | Description    |
-|-----------------------------|----------------|
-| Uint16                      | Unknown        |
-| [List]&lt;[RankingData]&gt; | Rank data list |
+| Type                        | Description      |
+|-----------------------------|------------------|
+| Sint16                      | Result code (30) |
+| [List]&lt;[RankingData]&gt; | Rank data list   |
 
 ### (16) GetTotal
 #### Request
 
-| Type   | Description            |
-|--------|------------------------|
-| Uint32 | Category               |
-| Uint8  | Unknown (1)            |
-| Uint8  | Unknown (2)            |
-| Uint8  | Unknown (3)            |
-| Uint32 | Unknown (4)            |
+| Type                                           | Description |
+|------------------------------------------------|-------------|
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+| Uint8                                          | Unknown (1) |
+| Uint8                                          | Unknown (2) |
+| Uint8                                          | Unknown (3) |
+| Uint32                                         | Unknown (4) |
 
 #### Response
 
-| Type   | Description |
-|--------|-------------|
-| Uint16 | Unknown     |
-| Uint32 | Total count |
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (30) |
+| Uint32 | Total count      |
 
 ### (17) UploadScoreWithLimit
+
+It is unknown how the limit affects the score.
+
 #### Request
 
 | Type                 | Description |
@@ -108,80 +316,74 @@ This protocol is the old version of the [Ranking](/docs/nex/protocols/ranking) p
 | [List]&lt;Uint32&gt; | Scores      |
 | Uint8                | Unknown (1) |
 | Uint32               | Unknown (2) |
-| Uint16               | Unknown (3) |
+| Uint16               | Limit       |
 
 #### Response
 
-| Type   | Description |
-|--------|-------------|
-| Uint16 | Unknown     |
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (50) |
 
-### (20) UploadSpecificPeriodScore
+### (18) UploadScoresWithLimit
 #### Request
 
-| Type   | Description |
-|--------|-------------|
-| Uint32 | Unique ID   |
-| Uint32 | Catrgory    |
-| Uint32 | Score       |
-| Uint8  | Unknown (1) |
-| Uint32 | Unknown (2) |
-| Uint16 | Unknown (3) |
+| Type                                  | Description |
+|---------------------------------------|-------------|
+| Uint32                                | Unique ID   |
+| [List]&lt;[RankingScoreWithLimit]&gt; | Scores      |
 
 #### Response
 
-| Type   | Description |
-|--------|-------------|
-| Uint16 | Unknown     |
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (50) |
 
-### (22) GetSpecificPeriodDataList
+### (19) UnknownMethod0x13
 #### Request
 
-| Type   | Description |
-|--------|-------------|
-| Uint32 | Unique ID   |
-| Uint32 | Category    |
-| Uint8  | Unknown (1) |
-| Uint8  | Unknown (2) |
-| Uint8  | Unknown (3) |
-| Uint32 | Offset      |
-| Uint8  | Length      |
+| Type                 | Description |
+|----------------------|-------------|
+| Uint32               | Unknown (1) |
+| Uint32               | Unknown (2) |
+| [List]&lt;Uint32&gt; | Unknown (3) |
+| [List]&lt;Uint8&gt;  | Unknown (4) |
 
 #### Response
 
-| Type                        | Description    |
-|-----------------------------|----------------|
-| Uint16                      | Unknown        |
-| Uint32                      | My score       |
-| [List]&lt;[RankingData]&gt; | Rank data list |
-
-### (25) GetSpecificPeriodTotal
-#### Request
-
-| Type   | Description  |
-|--------|--------------|
-| Uint32 | Category     |
-
-#### Response
-
-| Type   | Description |
-|--------|-------------|
-| Uint16 | Unknown     |
-| Uint32 | Total count |
+The response format of this method is unknown.
 
 ## Types
 ### RankingData ([Structure])
 
+| Type                                           | Description |
+|------------------------------------------------|-------------|
+| Uint32                                         | Unique ID   |
+| [PID]                                          | PID         |
+| Uint32                                         | Order       |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+| [List]&lt;Uint32&gt;                           | Scores      |
+| Uint8                                          | Unknown (1) |
+| Uint32                                         | Unknown (2) |
+| [Buffer]                                       | Common data |
+
+### RankingScore ([Structure])
+
+| Type                                           | Description |
+|------------------------------------------------|-------------|
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+| [List]&lt;Uint32&gt;                           | Scores      |
+| Uint8                                          | Unknown (1) |
+| Uint32                                         | Unknown (2) |
+
+### RankingScoreWithLimit ([Structure])
+
 | Type                 | Description |
 |----------------------|-------------|
-| Uint32               | Unique ID   |
-| [PID]                | PID         |
-| Uint32               | Order       |
 | Uint32               | Category    |
 | [List]&lt;Uint32&gt; | Scores      |
 | Uint8                | Unknown (1) |
 | Uint32               | Unknown (2) |
-| [Buffer]             | Common data |
+| Uint16               | Limit       |
 
 [Result]: /docs/nex/types#result
 [String]: /docs/nex/types#string
@@ -196,4 +398,7 @@ This protocol is the old version of the [Ranking](/docs/nex/protocols/ranking) p
 [PID]: /docs/nex/types#pid
 
 [RankingData]: #rankingdata-structure
+[RankingScore]: #rankingscore-structure
+[RankingScoreWithLimit]: #rankingscorewithlimit-structure
 [Ranking mode]: /docs/nex/protocols/ranking#ranking-mode
+[Rank calculation]: /docs/nex/protocols/ranking#rank-calculation

--- a/docs/nex/protocols/ranking/mario-kart-7.md
+++ b/docs/nex/protocols/ranking/mario-kart-7.md
@@ -1,0 +1,117 @@
+---
+layout: post
+toc: true
+title: Mario Kart 7 (112)
+---
+
+This page describes the methods that are only seen in Mario Kart 7.
+
+## Methods
+
+| Method ID         | Method Name                                                |
+|-------------------|------------------------------------------------------------|
+| 20                | [UploadSpecificPeriodScore](#20-uploadspecificperiodscore) |
+| 21                | ?                                                          |
+| 22                | [GetSpecificPeriodDataList](#22-getspecificperioddatalist) |
+| 23                | [UnknownMethod0x17](#23-unknownmethod0x17)                 |
+| 24                | ?                                                          |
+| 25                | [GetSpecificPeriodTotal](#25-getspecificperiodtotal)       |
+
+### (20) UploadSpecificPeriodScore
+
+It is unknown how the period affects the score.
+
+#### Request
+
+| Type   | Description |
+|--------|-------------|
+| Uint32 | Unique ID   |
+| Uint32 | Category    |
+| Uint32 | Score       |
+| Uint8  | Unknown (1) |
+| Uint32 | Unknown (2) |
+| Uint16 | Period      |
+
+#### Response
+
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (50) |
+
+### (22) GetSpecificPeriodDataList
+#### Request
+
+| Type   | Description |
+|--------|-------------|
+| Uint32 | Unique ID   |
+| Uint32 | Category    |
+| Uint8  | Unknown (1) |
+| Uint8  | Unknown (2) |
+| Uint8  | Unknown (3) |
+| Uint32 | Offset      |
+| Uint8  | Length      |
+
+#### Response
+
+| Type                        | Description      |
+|-----------------------------|------------------|
+| Sint16                      | Result code (30) |
+| Uint32                      | My score         |
+| [List]&lt;[RankingData]&gt; | Rank data list   |
+
+### (23) UnknownMethod0x17
+
+The number of entries returned matches with the number given as input. The entries may be related with `RankingData`, due to the similarities in layout. This method sometimes returns `Ranking::NotFound`.
+
+#### Request
+
+| Type   | Description       |
+|--------|-------------------|
+| Uint32 | Number of entries |
+
+#### Response
+
+| Type                                 | Description |
+|--------------------------------------|-------------|
+| [List]&lt;[UnknownStructure0x17]&gt; | Entries     |
+
+### (25) GetSpecificPeriodTotal
+#### Request
+
+| Type   | Description  |
+|--------|--------------|
+| Uint32 | Category     |
+
+#### Response
+
+| Type   | Description      |
+|--------|------------------|
+| Sint16 | Result code (30) |
+| Uint32 | Total count      |
+
+## Types
+
+### UnknownStructure0x17 ([Structure])
+
+| Type                 | Description |
+|----------------------|-------------|
+| Uint32               | ID          |
+| Uint32               | Unknown (1) |
+| [List]&lt;Uint32&gt; | Unknown (2) |
+| Uint8                | Unknown (3) |
+| Uint32               | Unknown (4) |
+
+[Result]: /docs/nex/types#result
+[String]: /docs/nex/types#string
+[Buffer]: /docs/nex/types#buffer
+[qBuffer]: /docs/nex/types#qbuffer
+[List]: /docs/nex/types#list
+[Map]: /docs/nex/types#map
+[DateTime]: /docs/nex/types#datetime
+[Structure]: /docs/nex/types#structure
+[Data]: /docs/nex/types#anydataholder
+[ResultRange]: /docs/nex/types#resultrange-structure
+[PID]: /docs/nex/types#pid
+
+[RankingData]: /docs/nex/protocols/ranking/legacy#rankingdata-structure
+[UnknownStructure0x17]: #unknownstructure0x17-structure

--- a/docs/nex/protocols/storage-manager.md
+++ b/docs/nex/protocols/storage-manager.md
@@ -6,12 +6,46 @@ title: Storage Manager (110)
 
 This protocol is the predecessor of the [Utility](/docs/nex/protocols/utility) protocol. It was replaced on NEX 3.0.0.
 
+Unique IDs are linked to either a user or a card ID. Each user or card ID has 5 zero-indexed slots for unique IDs, and they can't be assigned any more.
+
+Card IDs were introduced in NEX 2, and a user can use as much card IDs as they like. Card IDs aren't user-specific, but if a user tries to use a card ID given to another user, they will get assigned 5 new slots for unique IDs on the card ID, without altering the slots of the original user.
+
 ## Methods
 
-| Method ID | Method Name                                 |
-| --------- | ------------------------------------------- |
-| 4         | [AcquireCardId](#4-acquirecardid)           |
-| 5         | [ActivateWithCardId](#5-activatewithcardid) |
+| Method ID | Method Name                                             |
+|-----------|---------------------------------------------------------|
+| 1         | [AcquireNexUniqueId](#1-acquirenexuniqueid)             |
+| 2         | [NexUniqueIdToPrincipalId](#2-nexuniqueidtoprincipalid) |
+| 3         | ?                                                       |
+| 4         | [AcquireCardId](#4-acquirecardid)                       |
+| 5         | [ActivateWithCardId](#5-activatewithcardid)             |
+
+### (1) AcquireNexUniqueId
+#### Request
+
+| Type   | Description |
+|--------|-------------|
+| Uint8  | Slot        |
+
+#### Response
+
+| Type   | Description |
+|--------|-------------|
+| Uint32 | Unique ID   |
+| Bool   | First time  |
+
+### (2) NexUniqueIdToPrincipalId
+#### Request
+
+| Type   | Description |
+|--------|-------------|
+| Uint32 | Unique ID   |
+
+#### Response
+
+| Type  | Description  |
+|-------|--------------|
+| [PID] | Principal ID |
 
 ### (4) AcquireCardId
 #### Request
@@ -28,7 +62,7 @@ This method does not take any parameters.
 
 | Type   | Description |
 |--------|-------------|
-| Uint8  | Unknown     |
+| Uint8  | Slot        |
 | Uint64 | Card ID     |
 
 #### Response
@@ -37,3 +71,5 @@ This method does not take any parameters.
 |--------|-------------|
 | Uint32 | Unique ID   |
 | Bool   | First time  |
+
+[PID]: /docs/nex/types#pid


### PR DESCRIPTION
Marking as draft as we try to get more information before NN shutdown

In the meanwhile, we can review how information about the protocols and methods is presented and if any specific detail may be missing

We also want to look for better names for `UnknownMethod0xE` and `UnknownMethod0xF`. These methods are used to get the rank list (either global and friends with method 14, or global around own entry with method 15)