### PR TITLE
feat: Improvements on friends-3ds and authentication

### DIFF
--- a/docs/nex/protocols/authentication.md
+++ b/docs/nex/protocols/authentication.md
@@ -6,6 +6,8 @@ title: Ticket Granting (10)
 
 This is the only protocol that's available on the authentication server. Other protocols are only available on the secure server.
 
+If a server is in maintenance, the `%retval%` result fields are set to `Authentication::UnderMaintenance` and the other fields of the response are left with empty values.
+
 ## Methods
 
 | Method ID | Name (3DS / Wii U)                      | Name (Switch)                                                             |
@@ -20,7 +22,7 @@ This is the only protocol that's available on the authentication server. Other p
 ### (1) Login
 Usernames are not case sensitive.
 
-If the username does not exist, the `%retval%` field is set to `RendezVous::InvalidUsername` and the other fields are left blank.
+If the username does not exist, the `%retval%` field is set to `RendezVous::InvalidUsername` and the other fields are left with empty values.
 
 #### Request
 
@@ -49,7 +51,7 @@ Examples of server build names:
 ### (2) LoginEx
 Usernames are not case sensitive.
 
-If the username does not exist, the `%retval%` field is set to `RendezVous::InvalidUsername` and the other fields are left blank.
+If the username does not exist, the `%retval%` field is set to `RendezVous::InvalidUsername` and the other fields are left with empty values.
 
 Wii U servers don't seem to check what's in the extra data.
 

--- a/docs/nex/protocols/friends-3ds.md
+++ b/docs/nex/protocols/friends-3ds.md
@@ -449,12 +449,21 @@ Relationship types:
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]
 {: .prompt-info }
 
-| Type     | Description |
-| -------- | ----------- |
-| [String] | Name        |
-| Bool     | Unknown     |
-| Uint8    | Unknown     |
-| [Buffer] | Mii data    |
+| Type     | Description    |
+| -------- | -------------- |
+| [String] | Name           |
+| Bool     | Profanity flag |
+| Uint8    | Character set  |
+| [Buffer] | Mii data       |
+
+Character sets:
+
+| Value | Description     |
+|-------|-----------------|
+| 0     | JPN + USA + EUR |
+| 1     | CHN             |
+| 2     | KOR             |
+| 3     | TWN             |
 
 ### MiiList ([Structure])
 > This structure [inherits](/docs/nex/types#structure-inheritance) from [Data]


### PR DESCRIPTION
- Document unknown fields on `Mii` from friends-3ds. This is derived from the `FRDUA:UpdateMii` sysmodule command documented on [3dbrew](https://www.3dbrew.org/wiki/FRDA:UpdateMii), and has been further verified by checking the values on Nintendo's friends server from a Korean account.
- Clarify information about `%retval%` result fields on Ticket Granting. If `%retval%` has an error (like if the username doesn't exist), the other fields of the response are still initialized and written, but they will have empty values.