### PR TITLE
fix(match-making/types): Add missing docs for NEX 1.x and older

### DIFF
--- a/docs/nex/protocols/match-making/types.md
+++ b/docs/nex/protocols/match-making/types.md
@@ -112,7 +112,18 @@ In NEX version 4.0, the revision number was set back to 0 and one more field was
 | [String] | m_Codeword |
 
 ## MatchmakeSessionSearchCriteria ([Structure])
-Up to NEX version 2.x, this structure looks as follows:
+Up to NEX version 1.x, this structure looks as follows:
+
+| Type                   | Name                  |
+| ---------------------- | --------------------- |
+| [List]&lt;[String]&gt; | m_Attribs             |
+| [String]               | m_GameMode            |
+| [String]               | m_MatchmakeSystemType |
+| Bool                   | m_VacantOnly          |
+| Bool                   | m_ExcludeLocked       |
+| Bool                   | m_ExcludeNonHostPid   |
+
+In NEX version 2.0, the minimum and maximum participants fields were added. Note that these fields were inserted before the matchmaking system type field:
 
 | Type                   | Name                  |
 | ---------------------- | --------------------- |


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #27

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

In NEX 1.x and older, two string fields are missing from `MatchmakeSessionSearchCriteria`. Guessing from the values of the other two string fields on Street Fighter IV 3D Edition (the first one is empty and the second one is `m_MatchmakeSystemType`), the missing fields are `m_MinParticipants` and `m_MaxParticipants`. Document this version difference appropiately on the wiki.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.