### PR TITLE
Update PIA `Monitoring Data` protocol

### DIFF
--- a/docs/pia/protocols/monitoring-data.md
+++ b/docs/pia/protocols/monitoring-data.md
@@ -13,14 +13,14 @@ The message payload is encoded as follows:
 *Up to 5.6:*
 
 | Offset | Size | Description                                                                                                         |
-|--------|------|---------------------------------------------------------------------------------------------------------------------|
+| ------ | ---- | ------------------------------------------------------------------------------------------------------------------- |
 | 0x0    | 16   | [Monitoring data header](#monitoring-data-header)                                                                   |
 | 0x10   |      | Payload, first zlib compressed, then encrypted with AES-ECB. The key is always: `901edf193dc5ef3c5290647bff20c385`. |
 
 *5.7 and later:*
 
 | Offset | Size | Description                                                                                                       |
-|--------|------|-------------------------------------------------------------------------------------------------------------------|
+| ------ | ---- | ----------------------------------------------------------------------------------------------------------------- |
 | 0x0    | 16   | [Monitoring data header](#monitoring-data-header)                                                                 |
 | 0x10   |      | Payload, first zlib compressed, then encrypted with AES-GCM. See [AES-GCM encryption](#aes-gcm-encryption) below. |
 |        |      | AES-GCM authentication tag                                                                                        |
@@ -28,7 +28,7 @@ The message payload is encoded as follows:
 The content of the payload depends on the version number and data type in the monitoring data header.
 
 | Data Type | Payload content                                                       |
-|-----------|-----------------------------------------------------------------------|
+| --------- | --------------------------------------------------------------------- |
 | 0         | [Session begin monitoring content](#session-begin-monitoring-content) |
 | 1         | [Session end monitoring data](#session-end-monitoring-data)           |
 | 2         | [Session end monitoring data](#session-end-monitoring-data)           |
@@ -58,7 +58,7 @@ The key is chosen by the lower nybble of the encryption key id in the monitoring
 The nonce is constructed as follows:
 
 | Offset | Size | Description                       |
-|--------|------|-----------------------------------|
+| ------ | ---- | --------------------------------- |
 | 0x0    | 8    | Nonce from monitoring data header |
 | 0x8    | 4    | Always `5bd085fa`                 |
 
@@ -66,7 +66,7 @@ The nonce is constructed as follows:
 Monitoring was added to Pia in version 3.4.
 
 | Pia version | Monitoring version |
-|-------------|--------------------|
+| ----------- | ------------------ |
 | 3.4         | 1                  |
 | 3.5         | 2                  |
 | 3.6         | 3                  |
@@ -95,7 +95,7 @@ As described above, the message payload starts with a monitoring data header. Ea
 In the first monitoring data header, the payload size indicates the size of the compressed payload. In all other monitoring data headers, the payload size indicates the size of the structure, including the monitoring data header itself.
 
 | Offset | Size | Description                       |
-|--------|------|-----------------------------------|
+| ------ | ---- | --------------------------------- |
 | 0x0    | 1    | [Version number](#version-number) |
 | 0x1    | 1    | Data type                         |
 | 0x2    | 1    | Flags                             |
@@ -105,7 +105,7 @@ In the first monitoring data header, the payload size indicates the size of the 
 *Up to 5.6:*
 
 | Offset | Size | Description                |
-|--------|------|----------------------------|
+| ------ | ---- | -------------------------- |
 | 0x6    | 10   | Padding (filled with 0xFF) |
 
 *5.7 and later:*
@@ -113,7 +113,7 @@ In the first monitoring data header, the payload size indicates the size of the 
 This part is only relevant in the first monitoring data header. In all other monitoring data headers, it is filled with 0xFF.
 
 | Offset | Size | Description                       |
-|--------|------|-----------------------------------|
+| ------ | ---- | --------------------------------- |
 | 0x6    | 8    | AES-GCM nonce (random number)     |
 | 0xE    | 1    | Encryption key id (random number) |
 | 0xF    | 1    | Always 0xFF                       |
@@ -121,10 +121,53 @@ This part is only relevant in the first monitoring data header. In all other mon
 ## Session Begin Monitoring Content
 All fields are initialized to 0xFF.
 
+Version 7:
+
+| Offset | Size | Description                                                              |
+| ------ | ---- | ------------------------------------------------------------------------ |
+| 0x0    | 16   | [MonitoringDataHeader](#monitoring-data-header)                          |
+| 0x10   | 1    | PIA version major                                                        |
+| 0x11   | 1    | PIA version minor                                                        |
+| 0x12   | 1    | PIA version patch                                                        |
+| 0x1D   | 1    | Platform ID (3=Wii U)                                                    |
+| 0x1E   | 1    | [Region ID](https://nintendo-wiki.pretendo.network/docs/misc/region-ids) |
+| 0x37   | 4    | Uint32 client external IP address                                        |
+| 0x3B   | 4    | Uint32 client local IP address                                           |
+| 0x3F   | 1    | NAT Mapping                                                              |
+| 0x40   | 1    | NAT Filtering                                                            |
+| 0x42   | 1    | NAT type (flags)                                                         |
+| 0x4D   | 4    | First 4 bytes of the MD5 hash of the connected users PID                 |
+| 0x51   | 4    | Uint32 gathering ID                                                      |
+| 0x55   | 4    | Game server ID                                                           |
+| 0x19B  | 2    | Uint16 client external port                                              |
+| 0x19D  | 2    | Uint16 client local port                                                 |
+
+Version 11:
+
+| Offset | Size | Description                                                              |
+| ------ | ---- | ------------------------------------------------------------------------ |
+| 0x0    | 16   | [MonitoringDataHeader](#monitoring-data-header)                          |
+| 0x10   | 1    | PIA version major                                                        |
+| 0x11   | 1    | PIA version minor                                                        |
+| 0x12   | 1    | PIA version patch                                                        |
+| 0x1D   | 1    | Platform ID (3=Wii U)                                                    |
+| 0x1E   | 1    | [Region ID](https://nintendo-wiki.pretendo.network/docs/misc/region-ids) |
+| 0x37   | 4    | Uint32 client external IP address                                        |
+| 0x3B   | 4    | Uint32 client local IP address                                           |
+| 0x3F   | 1    | NAT Mapping                                                              |
+| 0x40   | 1    | NAT Filtering                                                            |
+| 0x42   | 1    | NAT type (flags)                                                         |
+| 0x4D   | 4    | First 4 bytes of the MD5 hash of the connected users PID                 |
+| 0x51   | 4    | Uint32 gathering ID                                                      |
+| 0x55   | 4    | Game server ID                                                           |
+| 0x14D  | 4    | First 4 bytes of the MD5 hash of the gathering hosts PID                 |
+| 0x19B  | 2    | Uint16 client external port                                              |
+| 0x19D  | 2    | Uint16 client local port                                                 |
+
 Version 18:
 
 | Type                                                            | Description                                                                                                                     |
-|-----------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | [MonitoringDataHeader](#monitoring-data-header)                 | Monitoring data header                                                                                                          |
 | Uint32                                                          | Pia version                                                                                                                     |
 | Uint32                                                          | SDK version                                                                                                                     |
@@ -293,7 +336,7 @@ Version 18:
 ### NexSessionSearchCriteria
 
 | Type        | Description                                                                                           |
-|-------------|-------------------------------------------------------------------------------------------------------|
+| ----------- | ----------------------------------------------------------------------------------------------------- |
 | Uint32      | Game mode                                                                                             |
 | Uint8       | Min participants num range (min)                                                                      |
 | Uint8       | Min participants num range (max)                                                                      |
@@ -309,7 +352,7 @@ Version 18:
 ### NexSessionSearchCriteriaExtra
 
 | Type   | Description        |
-|--------|--------------------|
+| ------ | ------------------ |
 | Uint32 | Rating value       |
 | Uint32 | Violation rate     |
 | Uint32 | Disconnection rate |
@@ -319,7 +362,7 @@ Version 18:
 ### Thread Mode
 
 | Mode | Description                       |
-|------|-----------------------------------|
+| ---- | --------------------------------- |
 | 0    | ThreadModeUndefined               |
 | 1    | ThreadModeSafeTransportBuffer     |
 | 2    | ThreadModeUnsafeTransportBuffer   |
@@ -331,7 +374,7 @@ Version 18:
 ### NAT Traversal Result
 
 | Value | Description                |
-|-------|----------------------------|
+| ----- | -------------------------- |
 | 0     | Reliable                   |
 | 1     | Unreliable                 |
 | 2     | Failure or very unreliable |
@@ -339,6 +382,6 @@ Version 18:
 ## Session End Monitoring Data
 
 | Offset | Size | Description                                       |
-|--------|------|---------------------------------------------------|
+| ------ | ---- | ------------------------------------------------- |
 | 0x0    | 16   | [Monitoring data header](#monitoring-data-header) |
 | ...    | ...  | ...                                               |

--- a/docs/pia/protocols/monitoring-data.md
+++ b/docs/pia/protocols/monitoring-data.md
@@ -23,7 +23,7 @@ The message payload is encoded as follows:
 | ------ | ---- | ----------------------------------------------------------------------------------------------------------------- |
 | 0x0    | 16   | [Monitoring data header](#monitoring-data-header)                                                                 |
 | 0x10   |      | Payload, first zlib compressed, then encrypted with AES-GCM. See [AES-GCM encryption](#aes-gcm-encryption) below. |
-|        |      | AES-GCM authentication tag                                                                                        |
+|        | 16   | AES-GCM authentication tag                                                                                        |
 
 The content of the payload depends on the version number and data type in the monitoring data header.
 

--- a/docs/pia/protocols/monitoring-data.md
+++ b/docs/pia/protocols/monitoring-data.md
@@ -92,7 +92,7 @@ Monitoring was added to Pia in version 3.4.
 ## Monitoring Data Header
 As described above, the message payload starts with a monitoring data header. Each monitoring data structure starts with a monitoring data header as well. The flags field is always 0xFC in the first monitoring data header, and 0xFF in all other monitoring data headers.
 
-In the first monitoring data header, the payload size indicates the size of the compressed payload. In all other monitoring data headers, the payload size indicates the size of the structure, including the monitoring data header itself.
+In the first monitoring data header, the payload size indicates the size of the compressed payload *after* the payload has been decrypted. In all other monitoring data headers, the payload size indicates the size of the structure, including the monitoring data header itself.
 
 | Offset | Size | Description                       |
 | ------ | ---- | --------------------------------- |

--- a/docs/pia/protocols/monitoring-data.md
+++ b/docs/pia/protocols/monitoring-data.md
@@ -127,7 +127,7 @@ Version 7:
 | ------ | ---- | ------------------------------------------------------------------------ |
 | 0x0    | 16   | [MonitoringDataHeader](#monitoring-data-header)                          |
 | 0x10   | 4    | PIA version (u8: major, u8: minor, u8: patch, u8: padding)               |
-| 0x1D   | 1    | Platform ID (3=Wii U)                                                    |
+| 0x1D   | 1    | Platform ID (2=3DS, 3=Wii U)                                             |
 | 0x1E   | 1    | [Region ID](https://nintendo-wiki.pretendo.network/docs/misc/region-ids) |
 | 0x37   | 4    | Uint32 client external IP address                                        |
 | 0x3B   | 4    | Uint32 client local IP address                                           |
@@ -142,23 +142,138 @@ Version 7:
 
 Version 11:
 
-| Offset | Size | Description                                                              |
-| ------ | ---- | ------------------------------------------------------------------------ |
-| 0x0    | 16   | [MonitoringDataHeader](#monitoring-data-header)                          |
-| 0x10   | 4    | PIA version (u8: major, u8: minor, u8: patch, u8: padding)               |
-| 0x1D   | 1    | Platform ID (3=Wii U)                                                    |
-| 0x1E   | 1    | [Region ID](https://nintendo-wiki.pretendo.network/docs/misc/region-ids) |
-| 0x37   | 4    | Uint32 client external IP address                                        |
-| 0x3B   | 4    | Uint32 client local IP address                                           |
-| 0x3F   | 1    | NAT Mapping                                                              |
-| 0x40   | 1    | NAT Filtering                                                            |
-| 0x42   | 1    | NAT type (flags)                                                         |
-| 0x4D   | 4    | First 4 bytes of the MD5 hash of the connected users PID                 |
-| 0x51   | 4    | Uint32 gathering ID                                                      |
-| 0x55   | 4    | Game server ID                                                           |
-| 0x14D  | 4    | First 4 bytes of the MD5 hash of the gathering hosts PID                 |
-| 0x19B  | 2    | Uint16 client external port                                              |
-| 0x19D  | 2    | Uint16 client local port                                                 |
+| Offset | Type                                                            | Description                                                                                                                     |
+|--------|-----------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| 0x0    | [MonitoringDataHeader](#monitoring-data-header)                 | Monitoring data header                                                                                                          |
+| 0x10   | Uint32                                                          | PIA version (u8: major, u8: minor, u8: patch, u8: padding)                                                                      |
+| 0x14   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x18   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x1C   | Uint8                                                           | Unknown                                                                                                                         |
+| 0x1D   | Uint8                                                           | Platform ID (2=3DS, 3=Wii U)                                                                                                    |
+| 0x1E   | Uint8                                                           | [Country ID](https://nintendo-wiki.pretendo.network/docs/misc/region-ids)                                                       |
+| 0x1F   | Uint8                                                           | [Region ID](https://nintendo-wiki.pretendo.network/docs/misc/region-ids)                                                        |
+| 0x20   | Uint32                                                          | Pia heap size                                                                                                                   |
+| 0x24   | Uint32                                                          | Bitmask that describes which [protocols](/docs/pia/protocols) are created.                                                      |
+| 0x28   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x2C   | Uint8                                                           | Unknown                                                                                                                         |
+| 0x2D   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x31   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x35   | Uint8                                                           | Unknown                                                                                                                         |
+| 0x36   | Uint8                                                           | Unknown                                                                                                                         |
+| 0x37   | Uint32                                                          | External client address                                                                                                         |
+| 0x3B   | Uint32                                                          | Local client address                                                                                                            |
+| 0x3F   | Uint8                                                           | NAT Mapping                                                                                                                     |
+| 0x40   | Uint8                                                           | NAT Filtering                                                                                                                   |
+| 0x42   | Uint8                                                           | NAT type (flags)                                                                                                                |
+| 0x43   | Uint16                                                          | Time used by NAT port detecter (milliseconds)                                                                                   |
+| 0x45   | Uint16                                                          | Time required to resolve address of NAT check server (milliseconds)                                                             |
+| 0x47   | Uint16                                                          | MTU size                                                                                                                        |
+| 0x49   | Uint32                                                          | NEX connection ID of the user                                                                                                   |
+| 0x4D   | Uint32                                                          | First 4 bytes of the MD5 hash of the connected users PID                                                                        |
+| 0x51   | Uint32                                                          | Gathering ID                                                                                                                    |
+| 0x55   | Uint32                                                          | Game server ID                                                                                                                  |
+| 0x59   | Uint8                                                           | [Thread mode](#thread-mode)                                                                                                     |
+| 0x5A   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x5E   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x62   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x66   | Uint8                                                           | Unknown                                                                                                                         |
+| 0x67   | Uint8                                                           | Unknown                                                                                                                         |
+| 0x68   | Uint16                                                          | Maximum number of stations allowed                                                                                              |
+| 0x6A   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x6E   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x72   | Uint32                                                          | Number of reliable send data blocks                                                                                             |
+| 0x76   | Uint32                                                          | Number of reliable receive data blocks                                                                                          |
+| 0x7A   | Uint32                                                          | Unknown                                                                                                                         |
+| 0x7E   | Uint16                                                          | Lowest RTT average (milliseconds)                                                                                               |
+| 0x80   | Uint32                                                          | First 4 bytes of the MD5 hash of the PID of the user with the lowest RTT average                                                |
+| 0x84   | Uint16                                                          | Highest RTT average (milliseconds)                                                                                              |
+| 0x86   | Uint32                                                          | First 4 bytes of the MD5 hash of the PID of the user with the highest RTT average                                               |
+| 0x8A   | Uint16                                                          | Relay route RTT max                                                                                                             |
+| 0x8C   | Uint16                                                          | Relay route num max                                                                                                             |
+| 0x8E   | Uint16                                                          | Maximum silence time (milliseconds)                                                                                             |
+| 0x90   | Uint32                                                          | Keep alive interval (milliseconds)                                                                                              |
+| 0x94   | Uint8                                                           | Unknown                                                                                                                         |
+| 0x95   | Uint8                                                           | Unknown                                                                                                                         |
+| 0x96   | Uint8                                                           | Unknown                                                                                                                         |
+| 0x97   | Uint32                                                          | Join mesh job result                                                                                                            |
+| 0x9B   | Uint32                                                          | Processing time of join mesh (milliseconds)                                                                                     |
+| 0x9F   | Uint8                                                           | PID relay count (1)                                                                                                             |
+| 0xA0   | Uint32[23]                                                      | First 4 bytes of the MD5 hash of the PIDs in relay (1)                                                                          |
+| 0xFC   | Uint8                                                           | PID relay count (2)                                                                                                             |
+| 0xFD   | Uint32[12]                                                      | First 4 bytes of the MD5 hash of the PIDs in relay (2)                                                                          |
+| 0x12D  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x12F  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x130  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x131  | Uint32                                                          | Unknown                                                                                                                         |
+| 0x135  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x137  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x139  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x13B  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x13D  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x13F  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x141  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x143  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x145  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x146  | Uint16                                                          | Unknown                                                                                                                         |
+| 0x148  | Uint16                                                          | External client port                                                                                                            |
+| 0x14A  | Uint16                                                          | Local client port                                                                                                               |
+| 0x14C  | Uint8                                                           | Debug mode (Wii U: OSGetSecurityLevel() != 0)                                                                                   |
+| 0x14D  | Uint32                                                          | First 4 bytes of the MD5 hash of the gathering hosts PID                                                                        |
+| 0x151  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x152  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x153  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x154  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x155  | Uint32                                                          | Joint session gathering ID                                                                                                      |
+| 0x159  | Uint32                                                          | Unknown                                                                                                                         |
+| 0x15D  | Uint32                                                          | Unknown                                                                                                                         |
+| 0x161  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x162  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x163  | Uint32                                                          | Processing time of join session (milliseconds)                                                                                  |
+| 0x167  | Uint32                                                          | Session game mode                                                                                                               |
+| 0x16B  | Uint32[6]                                                       | Session attributes                                                                                                              |
+| 0x183  | Uint16                                                          | Session max participants                                                                                                        |
+| 0x185  | [NexSessionSearchCriteria](#nexsessionsearchcriteria)           | Search criteria 1                                                                                                               |
+| 0x1A2  | [NexSessionSearchCriteria](#nexsessionsearchcriteria)           | Search criteria 2                                                                                                               |
+| 0x1BF  | Uint8                                                           | Joint number of session join attempts                                                                                           |
+| 0x1C0  | Uint8                                                           | Joint session max participants                                                                                                  |
+| 0x1C1  | Uint8                                                           | Session extra participants                                                                                                      |
+| 0x1C2  | [NexSessionSearchCriteriaExtra](#nexsessionsearchcriteriaextra) | Extra search criteria 1                                                                                                         |
+| 0x1D0  | [NexSessionSearchCriteriaExtra](#nexsessionsearchcriteriaextra) | Extra search criteria 2                                                                                                         |
+| 0x1DE  | Uint8                                                           | Number of NAT traversal failures                                                                                                |
+| 0x1DF  | Uint8                                                           | Number of session join failures because the connection with the host could not be established                                   |
+| 0x1E0  | Uint8                                                           | Number of session join failures because of an error receiving the join response                                                 |
+| 0x1E1  | Uint8                                                           | Number of session join failures because the session started host migration before a connection was established with all clients |
+| 0x1E2  | Uint8                                                           | Number of session join failures because the session started host migration before the join was completed                        |
+| 0x1E3  | Uint8                                                           | Number of session join failures because the join request was denied                                                             |
+| 0x1E4  | Uint32                                                          | Unknown                                                                                                                         |
+| 0x1E8  | Uint32                                                          | Unknown                                                                                                                         |
+| 0x1EC  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x1ED  | Uint8                                                           | Joint sequence                                                                                                                  |
+| 0x1EE  | Uint8                                                           | Join sequence                                                                                                                   |
+| 0x1EF  | Uint8                                                           | Join auto matchmake sequence                                                                                                    |
+| 0x1F0  | Uint8                                                           | Join mesh sequence                                                                                                              |
+| 0x1F1  | Uint8                                                           | Unknown                                                                                                                         |
+| 0x1F2  | Uint16                                                          | Bandwidth checker ip packet size                                                                                                |
+| 0x1F4  | Uint16                                                          | Unknown send packet num in measuring time                                                                                       |
+| 0x1F6  | Uint16                                                          | Bandwidth checker bps                                                                                                           |
+| 0x1FA  | Uint32                                                          | Unknown                                                                                                                         |
+| 0x1FE  | Uint16                                                          | NAT property detection count                                                                                                    |
+| 0x200  | Uint16                                                          | NAT port detection count                                                                                                        |
+| 0x202  | Uint32[23]                                                      | NEX connection IDs in the session                                                                                               |
+| 0x25E  | Uint32[23]                                                      | First 4 bytes of the MD5 hash of the PIDs in the session                                                                        |
+| 0x2BA  | Uint32[23]                                                      | Unknown (milliseconds)                                                                                                          |
+| 0x316  | Uint32[23]                                                      | Unknown (milliseconds)                                                                                                          |
+| 0x372  | Uint32[23]                                                      | NAT traversal results                                                                                                           |
+| 0x3CE  | Uint8[23]                                                       | Unknown                                                                                                                         |
+| 0x3E5  | Uint8[23]                                                       | Port spray counts                                                                                                               |
+| 0x3FC  | Uint8[23]                                                       | Unknown                                                                                                                         |
+| 0x414  | Uint8[23]                                                       | Unknown                                                                                                                         |
+| 0x42A  | Uint8                                                           | Start NAT traversal result                                                                                                      |
+| 0x42B  | Uint8                                                           | Complete NAT traversal result                                                                                                   |
+| 0x42C  | Uint16                                                          | Update target address count                                                                                                     |
+| 0x42E  | Uint16                                                          | NAT traversal success count                                                                                                     |
+| 0x430  | Uint16                                                          | NAT traversal failure count                                                                                                     |
+| 0x432  | Uint8[8]                                                        | Unknown                                                                                                                         |
 
 Version 18:
 
@@ -331,6 +446,24 @@ Version 18:
 
 ### NexSessionSearchCriteria
 
+Version 11:
+
+| Type       | Description                                                                                           |
+|------------|-------------------------------------------------------------------------------------------------------|
+| Uint32     | Game mode                                                                                             |
+| Uint8      | Min participants num range (min)                                                                      |
+| Uint8      | Min participants num range (max)                                                                      |
+| Uint8      | Max participants num range (min)                                                                      |
+| Uint8      | Max participants num range (max)                                                                      |
+| Uint8 (x6) | Attribute array size                                                                                  |
+| Uint8 (x6) | Attribute range min                                                                                   |
+| Uint8 (x6) | Attribute range max                                                                                   |
+| Uint8      | Matchmake system type                                                                                 |
+| Uint8      | Flags:<br>1: exclude user password set<br>2: exclude non host pid<br>4: opened only<br>8: vacant only |
+| Uint8      | Selection method                                                                                      |
+
+Version 18:
+
 | Type        | Description                                                                                           |
 | ----------- | ----------------------------------------------------------------------------------------------------- |
 | Uint32      | Game mode                                                                                             |
@@ -341,9 +474,9 @@ Version 18:
 | Uint8 (x6)  | Attribute array size                                                                                  |
 | Uint32 (x6) | Attribute range min                                                                                   |
 | Uint32 (x6) | Attribute range max                                                                                   |
-| Uint8       | Session type                                                                                          |
+| Uint8       | Matchmake system type                                                                                 |
 | Uint8       | Flags:<br>1: exclude user password set<br>2: exclude non host pid<br>4: opened only<br>8: vacant only |
-| Uint8       | Random session selection method                                                                       |
+| Uint8       | Selection method                                                                                      |
 
 ### NexSessionSearchCriteriaExtra
 

--- a/docs/pia/protocols/monitoring-data.md
+++ b/docs/pia/protocols/monitoring-data.md
@@ -126,9 +126,7 @@ Version 7:
 | Offset | Size | Description                                                              |
 | ------ | ---- | ------------------------------------------------------------------------ |
 | 0x0    | 16   | [MonitoringDataHeader](#monitoring-data-header)                          |
-| 0x10   | 1    | PIA version major                                                        |
-| 0x11   | 1    | PIA version minor                                                        |
-| 0x12   | 1    | PIA version patch                                                        |
+| 0x10   | 4    | PIA version (u8: major, u8: minor, u8: patch, u8: padding)               |
 | 0x1D   | 1    | Platform ID (3=Wii U)                                                    |
 | 0x1E   | 1    | [Region ID](https://nintendo-wiki.pretendo.network/docs/misc/region-ids) |
 | 0x37   | 4    | Uint32 client external IP address                                        |
@@ -147,9 +145,7 @@ Version 11:
 | Offset | Size | Description                                                              |
 | ------ | ---- | ------------------------------------------------------------------------ |
 | 0x0    | 16   | [MonitoringDataHeader](#monitoring-data-header)                          |
-| 0x10   | 1    | PIA version major                                                        |
-| 0x11   | 1    | PIA version minor                                                        |
-| 0x12   | 1    | PIA version patch                                                        |
+| 0x10   | 4    | PIA version (u8: major, u8: minor, u8: patch, u8: padding)               |
 | 0x1D   | 1    | Platform ID (3=Wii U)                                                    |
 | 0x1E   | 1    | [Region ID](https://nintendo-wiki.pretendo.network/docs/misc/region-ids) |
 | 0x37   | 4    | Uint32 client external IP address                                        |
@@ -169,9 +165,9 @@ Version 18:
 | Type                                                            | Description                                                                                                                     |
 | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | [MonitoringDataHeader](#monitoring-data-header)                 | Monitoring data header                                                                                                          |
-| Uint32                                                          | Pia version                                                                                                                     |
+| Uint32                                                          | Pia version (u8: major, u8: minor, u8: patch, u8: padding)                                                                      |
 | Uint32                                                          | SDK version                                                                                                                     |
-| Uint32                                                          | NEX version                                                                                                                     |
+| Uint32                                                          | NEX version (u8: major, u8: minor, u8: patch, u8: padding)                                                                      |
 | Uint8                                                           | Unknown                                                                                                                         |
 | Uint8                                                           | Unknown                                                                                                                         |
 | Uint8                                                           | Platform id (3=Wii U, 4=Switch)                                                                                                 |


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

- Adds the start of `Session Begin Monitoring Content` version 7 (seen in Mario Kart 8)
- Adds the start of `Session Begin Monitoring Content` version 11 (seen in Splatoon)
- Updates the `Monitoring Data Header` section to indicate that the payload size is the size *after* the payload has been decrypted
- Updates the message payload docs for PIA 5.7+ titles to include the AES-GCM authentication tag size

The new tables use a different style than the old ones because some of the data is confusingly documented in the old version. For example the PIA version field in `Session Begin Monitoring Content` version 18 is simply listed as a `Uint32`, when the actual data is individual bytes where each single byte makes up one section of the semver.

The data in`Session Begin Monitoring Content` versions 7 and 11 was found through a mix of REing data from network dumps directly as well as comparing to version 18 and using what lined up.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.