### PR TITLE
feat: Add missing notification types for Friends (3DS)

### DIFF
--- a/docs/nex/protocols/nintendo-notifications.md
+++ b/docs/nex/protocols/nintendo-notifications.md
@@ -65,7 +65,10 @@ No RMC response is sent.
 | 2    | 1      | [GameKey]                          | (3DS) A friend changed their favorite game                                                |
 | 3    | 1      | [NintendoNotificationEventGeneral] | (3DS) A friend changed their comment                                                      |
 | 5    | 1      | [NintendoNotificationEventGeneral] | (3DS) A friend changed or edited their mii                                                |
+| 6    | 1      | [NintendoNotificationEventProfile] | (3DS) A friend updated their profile                                                      |
 | 7    | 1      | [NintendoNotificationEventGeneral] | (3DS) You became friends                                                                  |
+| 8    | 1      | [NintendoNotificationEventGeneral] | (3DS) A friend deleted your friend card                                                   |
+| 9    | 1      | [NintendoNotificationEventGeneral] | (3DS) A friend sent you an invitation                                                     |
 | 10   | 1      | [NintendoNotificationEventGeneral] | (3DS / Wii U) A friend went offline                                                       |
 | 21   | 2      | [NNAInfo]                          | (Wii U) A friend changed or edited their mii                                              |
 | 22   |        |                                    | (Wii U) Mii related                                                                       |


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves part of #32 

### Changes:

Added the missing [notification types](https://nintendo-wiki.pretendo.network/docs/nex/protocols/nintendo-notifications#friend-events) for the Friends (3DS) protocol.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.