### PR TITLE
feat: Expand legacy Ranking and Storage Manager documentation

### DIFF
--- a/docs/nex/protocols/ranking/legacy.md
+++ b/docs/nex/protocols/ranking/legacy.md
@@ -38,8 +38,8 @@ The following games have additional methods in the legacy ranking protocol:
 | 9                 | 11                | [GetCommonData](#11-getcommondata)                 |
 | 10                | 12                | [UnknownMethod0xC](#12-unknownmethod0xc)           |
 | 11                | 13                | [UnknownMethod0xD](#13-unknownmethod0xd)           |
-| 12                | 14                | [UnknownMethod0xE](#14-unknownmethod0xe)           |
-| 13                | 15                | [UnknownMethod0xF](#15-unknownmethod0xf)           |
+| 12                | 14                | [GetScore](#14-getscore)                           |
+| 13                | 15                | [GetSelfScore](#15-getselfscore)                   |
 | 14                | 16                | [GetTotal](#16-gettotal)                           |
 |                   | 17                | [UploadScoreWithLimit](#17-uploadscorewithlimit)   |
 |                   | 18                | [UploadScoresWithLimit](#18-uploadscoreswithlimit) |
@@ -140,6 +140,7 @@ This method requires ownership of the unique ID, and having scores in the given 
 |------------------------------------------------|-------------|
 | Uint32                                         | Unique ID   |
 | [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
+| Uint8                                          | Unknown     |
 
 #### Response
 
@@ -156,6 +157,7 @@ This method requires ownership of the unique ID.
 | Type   | Description |
 |--------|-------------|
 | Uint32 | Unique ID   |
+| Uint8  | Unknown     |
 
 #### Response
 
@@ -224,12 +226,11 @@ The response format of this method is unknown.
 ### (13) UnknownMethod0xD
 #### Request
 
-| Type                                           | Description |
-|------------------------------------------------|-------------|
-| Uint32                                         | Unique ID   |
-| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category    |
-| Uint8                                          | Unknown (1) |
-| Uint8                                          | Unknown (2) |
+| Type                                           | Description         |
+|------------------------------------------------|---------------------|
+| Uint32                                         | Unique ID           |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category            |
+| [RankingOrderParam]                            | Ranking order param |
 
 #### Response
 
@@ -238,22 +239,16 @@ The response format of this method is unknown.
 | Sint16 | Result code (20) |
 | Uint32 | Unknown          |
 
-### (14) UnknownMethod0xE
+### (14) GetScore
 #### Request
 
-| Type                                           | Description                       |
-|------------------------------------------------|-----------------------------------|
-| Uint8                                          | [Ranking mode]                    |
-| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category                          |
-| Uint8                                          | Score index to order by           |
-| Uint8                                          | 0: Lowest score, 1: Highest score |
-| Uint8                                          | [Rank calculation]                |
-| Uint8                                          | Unknown (1)                       |
-| Uint8                                          | Unknown (2)                       |
-| Uint8                                          | Unknown (3)                       |
-| Uint32                                         | Unknown (4)                       |
-| Uint32                                         | Offset                            |
-| Uint8                                          | Length                            |
+| Type                                           | Description         |
+|------------------------------------------------|---------------------|
+| Uint8                                          | [Ranking mode]      |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category            |
+| [RankingOrderParam]                            | Ranking order param |
+| Uint32                                         | Offset              |
+| Uint8                                          | Length              |
 
 #### Response
 
@@ -262,21 +257,18 @@ The response format of this method is unknown.
 | Sint16                      | Result code (30) |
 | [List]&lt;[RankingData]&gt; | Rank data list   |
 
-### (15) UnknownMethod0xF
+### (15) GetSelfScore
+
+This method works in a similar way as `GetScore`, but it sets the ranking mode to 1 (global rankings around own entry).
+
 #### Request
 
-| Type                                           | Description                       |
-|------------------------------------------------|-----------------------------------|
-| Uint32                                         | Unique ID                         |
-| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category                          |
-| Uint8                                          | Score index to sort by            |
-| Uint8                                          | 0: Lowest score, 1: Highest score |
-| Uint8                                          | [Rank calculation]                |
-| Uint8                                          | Unknown (1)                       |
-| Uint8                                          | Unknown (2)                       |
-| Uint8                                          | Unknown (3)                       |
-| Uint32                                         | Unknown (4)                       |
-| Uint8                                          | Length                            |
+| Type                                           | Description         |
+|------------------------------------------------|---------------------|
+| Uint32                                         | Unique ID           |
+| [List]&lt;Uint16&gt; (NEX 1) or Uint32 (NEX 2) | Category            |
+| [RankingOrderParam]                            | Ranking order param |
+| Uint8                                          | Length              |
 
 #### Response
 
@@ -347,10 +339,14 @@ It is unknown how the limit affects the score.
 | Uint32               | Unknown (2) |
 | [List]&lt;Uint32&gt; | Unknown (3) |
 | [List]&lt;Uint8&gt;  | Unknown (4) |
+| Bool                 | Unknown (5) |
+| Uint16               | Unknown (6) |
 
 #### Response
 
-The response format of this method is unknown.
+| Type   | Description     |
+|--------|-----------------|
+| Sint16 | Result code (?) |
 
 ## Types
 ### RankingData ([Structure])
@@ -365,6 +361,18 @@ The response format of this method is unknown.
 | Uint8                                          | Unknown (1) |
 | Uint32                                         | Unknown (2) |
 | [Buffer]                                       | Common data |
+
+### RankingOrderParam ([Structure])
+
+| Type   | Description                       |
+|--------|-----------------------------------|
+| Uint8  | Score index to order by           |
+| Uint8  | 0: Lowest score, 1: Highest score |
+| Uint8  | [Rank calculation]                |
+| Uint8  | Unknown (1)                       |
+| Uint8  | Unknown (2)                       |
+| Uint8  | Unknown (3)                       |
+| Uint32 | Unknown (4)                       |
 
 ### RankingScore ([Structure])
 
@@ -398,6 +406,7 @@ The response format of this method is unknown.
 [PID]: /docs/nex/types#pid
 
 [RankingData]: #rankingdata-structure
+[RankingOrderParam]: #rankingorderparam-structure
 [RankingScore]: #rankingscore-structure
 [RankingScoreWithLimit]: #rankingscorewithlimit-structure
 [Ranking mode]: /docs/nex/protocols/ranking#ranking-mode

--- a/docs/nex/protocols/storage-manager.md
+++ b/docs/nex/protocols/storage-manager.md
@@ -16,7 +16,7 @@ Card IDs were introduced in NEX 2, and a user can use as much card IDs as they l
 |-----------|---------------------------------------------------------|
 | 1         | [AcquireNexUniqueId](#1-acquirenexuniqueid)             |
 | 2         | [NexUniqueIdToPrincipalId](#2-nexuniqueidtoprincipalid) |
-| 3         | ?                                                       |
+| 3         | [UnknownMethod0x3](#3-unknownmethod0x3)                 |
 | 4         | [AcquireCardId](#4-acquirecardid)                       |
 | 5         | [ActivateWithCardId](#5-activatewithcardid)             |
 
@@ -47,6 +47,17 @@ Card IDs were introduced in NEX 2, and a user can use as much card IDs as they l
 |-------|--------------|
 | [PID] | Principal ID |
 
+### (3) UnknownMethod0x3
+#### Request
+
+The request format of this method is unknown.
+
+#### Response
+
+| Type                 | Description |
+|----------------------|-------------|
+| [List]&lt;Uint32&gt; | Unknown     |
+
 ### (4) AcquireCardId
 #### Request
 This method does not take any parameters.
@@ -73,3 +84,4 @@ This method does not take any parameters.
 | Bool   | First time  |
 
 [PID]: /docs/nex/types#pid
+[List]: /docs/nex/types#list


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

The new information about the methods and their parameters has been obtained by reverse-engineering games which use legacy Ranking. This helps determine the real arguments of various methods, since these protocols didn't validate at the time that all the parameters were being provided properly.

Alongside that, this allows figuring out more information about the response parameters on some methods for which they were unknown. Interestingly, on method 0x13 of Ranking, the game only extracts the "result code", but this was documented at the time with an unknown format. It is unknown what those other parameters not being accounted here are, and the result code for this method has unfortunatelly been lost.

The new names assigned to the methods and structures are contextual guesses, and may not represent their real names. Similarly, like in other reverse-engineering efforts, the new parameters may be either signed or unsigned, but this is unknown given the assembly treats them the same way, so we are assuming all of them will be unsigned.

As an additional note, the methods documented as `GetScore` and `GetSelfScore` get called from the same function internally, and which one is called is determined by the ranking mode (if set to 1, it will call `GetSelfScore`, otherwise it calls `GetScore`).

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.