### PR TITLE
Add documentation for `Screening::ReportDataStoreContent`

### DIFF
--- a/docs/nex/protocols/screening.md
+++ b/docs/nex/protocols/screening.md
@@ -70,3 +70,4 @@ Enum representing the kind of content being reported.
 
 [String]: /docs/nex/types#string
 [List]: /docs/nex/types#list
+[Structure]: /docs/nex/types#structure

--- a/docs/nex/protocols/screening.md
+++ b/docs/nex/protocols/screening.md
@@ -22,7 +22,7 @@ Creates a report for a given piece of DataStore content (UGC).
 | [ScreeningUgcViolationParam](#screeningugcviolationparam-structure)         | pViolationParam |
 
 #### Response
-The response format of this method is unknown.
+This method does not return anything.
 
 ## Types
 ### ScreeningDataStoreContentParam ([Structure])

--- a/docs/nex/protocols/screening.md
+++ b/docs/nex/protocols/screening.md
@@ -6,7 +6,67 @@ title: Screening (124)
 
 ## Methods
 
-| Method ID | Method Name            |
-| --------- | ---------------------- |
-| 1         | ReportDataStoreContent |
-| 2         | ReportUser             |
+| Method ID | Method Name                                         |
+| --------- | --------------------------------------------------- |
+| 1         | [ReportDataStoreContent](#1-reportdatastorecontent) |
+| 2         | ReportUser                                          |
+
+### (1) ReportDataStoreContent
+Creates a report for a given piece of DataStore content (UGC).
+
+#### Request
+
+| Type                                                                        | Name            |
+| --------------------------------------------------------------------------- | --------------- |
+| [ScreeningDataStoreContentParam](#screeningdatastorecontentparam-structure) | pContentParam   |
+| [ScreeningUgcViolationParam](#screeningugcviolationparam-structure)         | pViolationParam |
+
+#### Response
+The response format of this method is unknown.
+
+## Types
+### ScreeningDataStoreContentParam ([Structure])
+
+| Type     | Name          |
+| -------- | ------------- |
+| Uint64   | dataId        |
+| Uint64   | contentDataId |
+| [String] | ugcType       |
+| [String] | language      |
+| [String] | searchKey     |
+
+### ScreeningUgcViolationParam ([Structure])
+
+| Type                                                                  | Name             |
+| --------------------------------------------------------------------- | ---------------- |
+| [ReportCategory](#reportcategory-uint32)                              | category         |
+| [String]                                                              | reason           |
+| [List]&lt;[ScreeningContextInfo](#screeningcontextinfo-structure)&gt; | context          |
+| Uint64                                                                | screenshotDataId |
+
+### ScreeningContextInfo ([Structure])
+
+| Type     | Name  |
+| -------- | ----- |
+| [String] | key   |
+| [String] | value |
+
+## Constants
+### ReportCategory (Uint32)
+Enum representing the kind of content being reported.
+
+| Name                                | Value | Description                                                         |
+| ----------------------------------- | ----- | ------------------------------------------------------------------- |
+| `REPORT_CATEGORY_INVALID`           | 0     | Invalid category.                                                   |
+| `REPORT_CATEGORY_MIN`               | 1     | The minimum value a category can be.                                |
+| `REPORT_CATEGORY_PERSONAL`          | 1     | The reported content contained personal information.                |
+| `REPORT_CATEGORY_CRIMINAL`          | 2     | The reported content contained criminal material.                   |
+| `REPORT_CATEGORY_IMMORAL`           | 3     | The reported content contained "immoral" (?) material.              |
+| `REPORT_CATEGORY_HARASSMENT`        | 4     | The reported content contained harassment material.                 |
+| `REPORT_CATEGORY_COMMERCIAL`        | 5     | The reported content contained commercial (advertising?) material.  |
+| `REPORT_CATEGORY_SEXUALLY_EXPLICIT` | 6     | The reported content contained sexually explicit material.          |
+| `REPORT_CATEGORY_OTHER`             | 7     | The reported content didn't fit into the other existing categories. |
+| `REPORT_CATEGORY_MAX`               | 7     | The maximum value a category can be.                                |
+
+[String]: /docs/nex/types#string
+[List]: /docs/nex/types#list


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds proper documentation for `Screening::ReportDataStoreContent`

Data comes from:

- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/no_namespace/Detail.cs#L1627
- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/NexPlugin/ScreeningDataStoreContentParam.cs
- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/NexPlugin/ScreeningUgcViolationParam.cs
- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/NexPlugin/ScreeningContextInfo.cs
- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/no_namespace/Screening.cs#L13

Sadly there's no details for `Screening:: ReportUser`. The struct field order is assumed to be correct. Sister PR of https://github.com/PretendoNetwork/nex-protocols-go/pull/106

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.